### PR TITLE
chore(deps): use published versions of ffi-toolkit and drpo_struct_macro_derive

### DIFF
--- a/sector-builder-ffi/Cargo.toml
+++ b/sector-builder-ffi/Cargo.toml
@@ -14,8 +14,8 @@ publish = false
 crate-type = ["rlib", "cdylib", "staticlib"]
 
 [dependencies]
-drop_struct_macro_derive = { rev = "c9c9d55a0810a017b0e18fddf5593e84b366daad", git = "https://github.com/filecoin-project/rust-fil-ffi-toolkit.git" }
-ffi-toolkit = { rev = "c9c9d55a0810a017b0e18fddf5593e84b366daad", git = "https://github.com/filecoin-project/rust-fil-ffi-toolkit.git" }
+drop_struct_macro_derive = "0.3.0"
+ffi-toolkit = "0.3.0"
 filecoin-proofs = { rev = "07de4ef9eac5400335229678c0cc01ab8d967273", git = "https://github.com/filecoin-project/rust-fil-proofs.git" }
 filecoin-proofs-ffi = { rev = "9e764cad9e25cb3667fcc204d2f0c0dc36e8f8f1", git = "https://github.com/filecoin-project/rust-fil-proofs-ffi.git" }
 logging-toolkit = "^0.2"


### PR DESCRIPTION
Ref https://github.com/filecoin-project/rust-fil-proofs/issues/707