### PR TITLE
bug(allocate once, not thrice)

### DIFF
--- a/sector-builder/src/helpers/snapshots.rs
+++ b/sector-builder/src/helpers/snapshots.rs
@@ -40,7 +40,7 @@ pub fn load_snapshot<T: KeyValueStore>(
 impl From<&SnapshotKey> for Vec<u8> {
     fn from(n: &SnapshotKey) -> Self {
         // convert the sector size to a byte vector
-        let mut snapshot_key = vec![];
+        let mut snapshot_key = Vec::with_capacity(n.prover_id.len() + 8);
         snapshot_key
             .write_u64::<LittleEndian>(u64::from(n.sector_size))
             .unwrap();


### PR DESCRIPTION
## Why does this PR exist?

We always know how many bytes we'll need in the vector, so go ahead and allocate the whole thing at once.