### PR TITLE
feat(consume published crates)

### DIFF
--- a/sector-builder-ffi/Cargo.toml
+++ b/sector-builder-ffi/Cargo.toml
@@ -16,9 +16,9 @@ crate-type = ["rlib", "cdylib", "staticlib"]
 [dependencies]
 drop_struct_macro_derive = "0.3.0"
 ffi-toolkit = "0.3.0"
-filecoin-proofs = { rev = "07de4ef9eac5400335229678c0cc01ab8d967273", git = "https://github.com/filecoin-project/rust-fil-proofs.git" }
-filecoin-proofs-ffi = { rev = "9e764cad9e25cb3667fcc204d2f0c0dc36e8f8f1", git = "https://github.com/filecoin-project/rust-fil-proofs-ffi.git" }
-logging-toolkit = "^0.2"
+filecoin-proofs = "0.3.0"
+filecoin-proofs-ffi = "0.4.0"
+logging-toolkit = "0.3.0"
 sector-builder = { version = "^0.1", path = "../sector-builder" }
 
 slog = "2.4.1"

--- a/sector-builder/Cargo.toml
+++ b/sector-builder/Cargo.toml
@@ -13,9 +13,9 @@ bitvec = "0.11"
 failure = "0.1.5"
 itertools = "0.8"
 rand = "0.4"
-filecoin-proofs = { rev = "07de4ef9eac5400335229678c0cc01ab8d967273", git = "https://github.com/filecoin-project/rust-fil-proofs.git" }
-logging-toolkit = "^0.2"
-storage-proofs = "^0.2"
+filecoin-proofs = "0.3.0"
+logging-toolkit = "0.3.0"
+storage-proofs = "0.3.0"
 serde_cbor = "0.9.0"
 serde = { version = "1.0.92", features = ["rc", "derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
## Why does this PR exist?

We're currently pinned to Git SHAs. We should instead point to crates.io-hosted crate versions.