### PR TITLE
feat(add piece expiry time, in secs since epoch, to API)

### DIFF
--- a/sector-builder-ffi/examples/simple.rs
+++ b/sector-builder-ffi/examples/simple.rs
@@ -74,6 +74,7 @@ unsafe fn create_and_add_piece(
             c_piece_key,
             piece_bytes.len() as u64,
             c_piece_path,
+            5000000000,
         ),
     )
 }

--- a/sector-builder-ffi/src/api.rs
+++ b/sector-builder-ffi/src/api.rs
@@ -7,7 +7,7 @@ use slog::*;
 
 use ffi_toolkit::rust_str_to_c_str;
 use ffi_toolkit::{c_str_to_rust_str, raw_ptr};
-use sector_builder::{PieceMetadata, SealStatus, SectorBuilder};
+use sector_builder::{PieceMetadata, SealStatus, SecondsSinceEpoch, SectorBuilder};
 
 use crate::responses::{
     self, err_code_and_msg, FCPResponseStatus, FFIPieceMetadata, FFISealStatus,
@@ -30,6 +30,7 @@ pub unsafe extern "C" fn sector_builder_ffi_add_piece(
     piece_key: *const libc::c_char,
     piece_bytes_amount: u64,
     piece_path: *const libc::c_char,
+    store_until_utc_secs: u64,
 ) -> *mut responses::AddPieceResponse {
     let piece_key = c_str_to_rust_str(piece_key);
     let piece_path = c_str_to_rust_str(piece_path);
@@ -40,6 +41,7 @@ pub unsafe extern "C" fn sector_builder_ffi_add_piece(
         String::from(piece_key),
         piece_bytes_amount,
         String::from(piece_path),
+        SecondsSinceEpoch(store_until_utc_secs),
     ) {
         Ok(sector_id) => {
             response.status_code = FCPResponseStatus::FCPNoError;

--- a/sector-builder/src/builder.rs
+++ b/sector-builder/src/builder.rs
@@ -105,12 +105,11 @@ impl SectorBuilder {
         piece_key: String,
         piece_bytes_amount: u64,
         piece_path: String,
+        store_until: SecondsSinceEpoch,
     ) -> Result<SectorId> {
-        log_unrecov(
-            self.run_blocking(|tx| {
-                Request::AddPiece(piece_key, piece_bytes_amount, piece_path, tx)
-            }),
-        )
+        log_unrecov(self.run_blocking(|tx| {
+            Request::AddPiece(piece_key, piece_bytes_amount, piece_path, store_until, tx)
+        }))
     }
 
     // Returns sealing status for the sector with specified id. If no sealed or

--- a/sector-builder/src/helpers/add_piece.rs
+++ b/sector-builder/src/helpers/add_piece.rs
@@ -9,7 +9,7 @@ use filecoin_proofs::types::UnpaddedBytesAmount;
 
 use crate::builder::*;
 use crate::error::*;
-use crate::metadata::{self, SealStatus, StagedSectorMetadata};
+use crate::metadata::{self, SealStatus, SecondsSinceEpoch, StagedSectorMetadata};
 use crate::state::StagedState;
 use crate::store::{SectorManager, SectorStore};
 
@@ -19,6 +19,7 @@ pub fn add_piece(
     piece_key: String,
     piece_bytes_amount: u64,
     piece_path: String,
+    _store_until: SecondsSinceEpoch,
 ) -> Result<SectorId> {
     let sector_mgr = sector_store.manager();
     let sector_max = sector_store.sector_config().max_unsealed_bytes_per_sector();

--- a/sector-builder/src/metadata.rs
+++ b/sector-builder/src/metadata.rs
@@ -42,6 +42,9 @@ pub enum SealStatus {
     Sealing,
 }
 
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+pub struct SecondsSinceEpoch(pub u64);
+
 impl PartialEq for SealedSectorMetadata {
     fn eq(&self, other: &SealedSectorMetadata) -> bool {
         self.sector_id == other.sector_id


### PR DESCRIPTION
Fixes #19 

## Why does this PR exist?

Our current add_piece API does not allow a caller to provide information about how long it expects the sector builder to hold on to a piece. This means that the sector builder does not have enough information to colocate pieces with similar time (i.e. deal) constraints. It is dumb to keep a huge sector around because one out of a hundred pieces that it contains doesn't expire until far into the future. We need to give miners enough information to group pieces together if they so choose.

## What's in this PR?

This PR makes incremental progress towards a bin packing strategy which allows miners to colocate pieces with similar time constraints. Note that the changeset doesn't actually do anything with this value yet.