### PR TITLE
obtain filecoin proofs bins from cargo install

### DIFF
--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 if [ -z "$1" ]; then
   TAR_FILE=`mktemp`.tar.gz
 else
@@ -9,12 +11,18 @@ fi
 TAR_PATH=`mktemp -d`
 
 mkdir -p $TAR_PATH
+mkdir -p $TAR_PATH/bin
 mkdir -p $TAR_PATH/include
 mkdir -p $TAR_PATH/lib/pkgconfig
 
 find . -type f -name sector_builder_ffi.h -exec cp -- "{}" $TAR_PATH/include/ \;
 find . -type f -name libsector_builder_ffi.a -exec cp -- "{}" $TAR_PATH/lib/ \;
 find . -type f -name sector_builder_ffi.pc -exec cp -- "{}" $TAR_PATH/lib/pkgconfig/ \;
+
+# TODO https://github.com/filecoin-project/rust-fil-sector-builder/issues/39
+FP_VERSION=$(cat Cargo.lock | grep 'name = "filecoin-proofs"' -A1 | tail -n1 | cut -d' ' -f3 | tr -d '"')
+
+cargo install --version $FP_VERSION filecoin-proofs --root $TAR_PATH --bin paramfetch
 
 pushd $TAR_PATH
 


### PR DESCRIPTION
# What's in this pr?

uses `cargo install` to obtain `paramfetch`, and package it in with a `rust-fil-sector-builder` release
