### PR TITLE
build(point to master instead of crates.io release)

### DIFF
--- a/sector-builder-ffi/Cargo.toml
+++ b/sector-builder-ffi/Cargo.toml
@@ -16,10 +16,10 @@ crate-type = ["rlib", "cdylib", "staticlib"]
 [dependencies]
 drop_struct_macro_derive = "0.3.0"
 ffi-toolkit = "0.3.0"
-filecoin-proofs = "0.6.4"
-filecoin-proofs-ffi = "0.7.3"
-sector-builder = { version = "^0.5", path = "../sector-builder" }
-storage-proofs = "0.6.2"
+filecoin-proofs = { git = "https://github.com/filecoin-project/rust-fil-proofs.git", branch = "master" }
+storage-proofs = { git = "https://github.com/filecoin-project/rust-fil-proofs.git", branch = "master" }
+filecoin-proofs-ffi = { git = "https://github.com/filecoin-project/rust-fil-proofs-ffi.git", branch = "master" }
+sector-builder = { path = "../sector-builder" }
 failure = "0.1.5"
 libc = "0.2.58"
 pretty_env_logger = "0.3.0"

--- a/sector-builder/Cargo.toml
+++ b/sector-builder/Cargo.toml
@@ -7,14 +7,15 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 repository = "https://github.com/filecoin-project/rust-fil-proofs"
 readme = "README.md"
+publish = false
 
 [dependencies]
 bitvec = "0.11"
 failure = "0.1.5"
 itertools = "0.8"
 rand = "0.4"
-filecoin-proofs = "0.6.4"
-storage-proofs = "0.6.2"
+filecoin-proofs = { git = "https://github.com/filecoin-project/rust-fil-proofs.git", branch = "master" }
+storage-proofs = { git = "https://github.com/filecoin-project/rust-fil-proofs.git", branch = "master" }
 serde_cbor = "0.9.0"
 serde = { version = "1.0.92", features = ["rc", "derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
## Why does this PR exist?

We need to be able to consume changes in rust-fil-sector-builder without having to first release to crates.io.