### PR TITLE
exercise full FFI test suite using 256MiB sectors (seal, PoSt-generation, PIPs, health checks, etc.)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - configure_env
       - install_rust
       - run:
-          name: Ensure cache is hydrated with PoRep and PoSt Groth parameters (for test)
+          name: Install paramfetch from head of rust-fil-proofs master branch
           command: |
             # install paramfetch
             cargo install filecoin-proofs --bin=paramcache --force --git=https://github.com/filecoin-project/rust-fil-proofs.git --branch=master
@@ -27,6 +27,7 @@ jobs:
           paths:
             - paramfetch-checksum.txt
       - save_parameter_cache
+
   cargo_fetch:
     docker:
       - image: filecoin/rust:latest
@@ -224,6 +225,10 @@ jobs:
       xcode: "10.0.0"
     working_directory: ~/crate
     resource_class: large
+    parameters:
+      create_github_release:
+        type: boolean
+        default: false
     steps:
       - configure_env
       - install_rust
@@ -243,7 +248,7 @@ jobs:
           command: ./scripts/build-release.sh $(cat ./rust-toolchain) --verbose --all
       - run:
           name: Publish release to GitHub
-          command: bash ./scripts/publish-release.sh
+          command: true; <<# parameters.create_github_release >> bash ./scripts/publish-release.sh <</ parameters.create_github_release >>
 
 workflows:
   version: 2
@@ -285,6 +290,14 @@ workflows:
             branches:
               only: master
       - build_darwin_release:
+          create_github_release: false
+          requires:
+            - cargo_fetch
+          filters:
+            branches:
+              ignore: master
+      - build_darwin_release:
+          create_github_release: true
           requires:
             - cargo_fetch
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,31 @@
 version: 2.1
 
 jobs:
+  obtain_parameters:
+    docker:
+      - image: filecoin/rust:latest
+    working_directory: /mnt/crate
+    resource_class: xlarge
+    steps:
+      - configure_env
+      - run:
+          name: Ensure cache is hydrated with PoRep and PoSt Groth parameters (for test)
+          command: |
+            # install paramfetch
+            cargo install filecoin-proofs --bin=paramcache --force --git=https://github.com/filecoin-project/rust-fil-proofs.git --branch=master
+            which paramcache || { printf '%s\n' "missing paramcache binary" >&2; exit 1; }
+      - run:
+          name: create paramfetch checksum
+          command: md5sum $(which paramfetch) | cut -d ' ' -f 1 >> paramfetch-checksum.txt
+      - restore_parameter_cache
+      - run:
+          name: Generate Groth parameters and verifying keys
+          command: paramcache
+      - persist_to_workspace:
+          root: "."
+          paths:
+            - paramfetch-checksum.txt
+      - save_parameter_cache
   cargo_fetch:
     docker:
       - image: filecoin/rust:latest
@@ -21,25 +46,10 @@ jobs:
       - run: cargo fetch
       - run: rustc +stable --version
       - run: rustc +$(cat rust-toolchain) --version
-      - run:
-          name: Ensure cache is hydrated with PoRep and PoSt Groth parameters (for test)
-          command: |
-            # install paramfetch
-            cargo install filecoin-proofs --bin=paramcache --force --git=https://github.com/filecoin-project/rust-fil-proofs.git --branch=master
-            which paramcache || { printf '%s\n' "missing paramcache binary" >&2; exit 1; }
-      - run:
-          name: create paramfetch checksum
-          command: md5sum $(which paramfetch) | cut -d ' ' -f 1 >> paramfetch-checksum.txt
-      - restore_parameter_cache
-      - run:
-          name: Generate Groth parameters and verifying keys
-          command: paramcache
       - persist_to_workspace:
           root: "."
           paths:
             - Cargo.lock
-            - paramfetch-checksum.txt
-      - save_parameter_cache
       - save_rust_cache
 
   test:
@@ -240,6 +250,7 @@ workflows:
   version: 2
   test_all:
     jobs:
+      - obtain_parameters
       - cargo_fetch
       - rustfmt:
           requires:
@@ -254,9 +265,11 @@ workflows:
           use_256M_sector_size: false
           requires:
             - cargo_fetch
+            - obtain_parameters
       - test_ignored_release:
           requires:
             - cargo_fetch
+            - obtain_parameters
       - test:
           requires:
             - cargo_fetch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
     resource_class: xlarge
     steps:
       - configure_env
+      - install_rust
       - run:
           name: Ensure cache is hydrated with PoRep and PoSt Groth parameters (for test)
           command: |
@@ -33,6 +34,7 @@ jobs:
     resource_class: xlarge
     steps:
       - configure_env
+      - install_rust
       - checkout
       - run:
           name: Calculate dependencies
@@ -224,11 +226,8 @@ jobs:
     resource_class: large
     steps:
       - configure_env
+      - install_rust
       - checkout
-      - run:
-          name: Install Rust
-          command: |
-            curl https://sh.rustup.rs -sSf | sh -s -- -y
       - run: rustup install $(cat rust-toolchain)
       - run: rustup default $(cat rust-toolchain)
       - run: cargo update
@@ -304,6 +303,7 @@ commands:
             echo 'export CARGO_HOME=/tmp/cargo' >> $BASH_ENV
             echo 'export RUSTUP_HOME=/tmp/rustup' >> $BASH_ENV
             echo 'export CIRCLE_ARTIFACTS=/tmp/circle-ci-artifacts' >> $BASH_ENV
+            echo 'export PATH="${CARGO_HOME}/bin:${PATH}"' >> $BASH_ENV
             source $BASH_ENV
   restore_parameter_cache:
     steps:
@@ -328,3 +328,9 @@ commands:
           paths:
             - /tmp/cargo
             - /tmp/rustup
+  install_rust:
+    steps:
+      - run:
+          name: Install Rust
+          command: |
+            curl https://sh.rustup.rs -sSf | sh -s -- -y

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,10 @@ jobs:
       - image: filecoin/rust:latest
     working_directory: /mnt/crate
     resource_class: xlarge
+    parameters:
+      use_256M_sector_size:
+        type: boolean
+        default: false
     steps:
       - linux_configure_env
       - checkout
@@ -107,7 +111,7 @@ jobs:
           command: ./scripts/build-release.sh $(cat ./rust-toolchain) --verbose --package sector-builder-ffi
       - run:
           name: run regression tests (examples) against libsector_builder_ffi.a
-          command: RUSTFLAGS="-L ./target/release -Z sanitizer=leak" cargo run --release --package sector-builder-ffi --example simple --target x86_64-unknown-linux-gnu
+          command: <<# parameters.use_256M_sector_size >> TEST_LIVE_SEAL=true <</ parameters.use_256M_sector_size >> RUSTFLAGS="-L ./target/release -Z sanitizer=leak" cargo run --release --package sector-builder-ffi --example simple --target x86_64-unknown-linux-gnu
 
   test_ignored_release:
     docker:
@@ -268,6 +272,7 @@ workflows:
           requires:
             - cargo_fetch
       - ffi_regression:
+          use_256M_sector_size: false
           requires:
             - cargo_fetch
       - test_ignored_release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     working_directory: /mnt/crate
     resource_class: xlarge
     steps:
-      - linux_configure_env
+      - configure_env
       - checkout
       - run:
           name: Calculate dependencies
@@ -48,7 +48,7 @@ jobs:
     working_directory: /mnt/crate
     resource_class: xlarge
     steps:
-      - linux_configure_env
+      - configure_env
       - checkout
       - attach_workspace:
           at: "."
@@ -74,7 +74,7 @@ jobs:
     working_directory: /mnt/crate
     resource_class: xlarge
     steps:
-      - linux_configure_env
+      - configure_env
       - checkout
       - attach_workspace:
           at: "."
@@ -95,7 +95,7 @@ jobs:
         type: boolean
         default: false
     steps:
-      - linux_configure_env
+      - configure_env
       - checkout
       - attach_workspace:
           at: "."
@@ -114,7 +114,7 @@ jobs:
     working_directory: /mnt/crate
     resource_class: xlarge
     steps:
-      - linux_configure_env
+      - configure_env
       - checkout
       - attach_workspace:
           at: "."
@@ -130,7 +130,7 @@ jobs:
     working_directory: /mnt/crate
     resource_class: xlarge
     steps:
-      - linux_configure_env
+      - configure_env
       - checkout
       - attach_workspace:
           at: "."
@@ -146,7 +146,7 @@ jobs:
     working_directory: /mnt/crate
     resource_class: xlarge
     steps:
-      - linux_configure_env
+      - configure_env
       - checkout
       - attach_workspace:
           at: "."
@@ -162,7 +162,7 @@ jobs:
     working_directory: /mnt/crate
     resource_class: xlarge
     steps:
-      - linux_configure_env
+      - configure_env
       - checkout
       - attach_workspace:
           at: "."
@@ -177,7 +177,7 @@ jobs:
     working_directory: /mnt/crate
     resource_class: xlarge
     steps:
-      - linux_configure_env
+      - configure_env
       - checkout
       - attach_workspace:
           at: "."
@@ -192,7 +192,7 @@ jobs:
     working_directory: /mnt/crate
     resource_class: xlarge
     steps:
-      - linux_configure_env
+      - configure_env
       - checkout
       - attach_workspace:
           at: "."
@@ -213,12 +213,7 @@ jobs:
     working_directory: ~/crate
     resource_class: large
     steps:
-      - run:
-          name: Configure environment variables
-          command: |
-            echo 'export RUST_LOG=info' >> $BASH_ENV
-            echo 'export PATH="${HOME}/.cargo/bin:${HOME}/.bin:${PATH}"' >> $BASH_ENV
-            echo 'export CIRCLE_ARTIFACTS="/tmp"' >> $BASH_ENV
+      - configure_env
       - checkout
       - run:
           name: Install Rust
@@ -285,21 +280,24 @@ workflows:
               only: master
 
 commands:
-  linux_configure_env:
+  configure_env:
     steps:
       - run:
           name: Configure environment variables
           command: |
             echo 'export RUST_LOG=info' >> $BASH_ENV
-            echo 'export FILECOIN_PARAMETER_CACHE="/root/.filecoin-parameter-cache"' >> $BASH_ENV
+            echo 'export FILECOIN_PARAMETER_CACHE="/tmp/filecoin-parameter-cache"' >> $BASH_ENV
             echo 'export RUST_BACKTRACE=1' >> $BASH_ENV
+            echo 'export CARGO_HOME=/tmp/cargo' >> $BASH_ENV
+            echo 'export RUSTUP_HOME=/tmp/rustup' >> $BASH_ENV
+            echo 'export CIRCLE_ARTIFACTS=/tmp/circle-ci-artifacts' >> $BASH_ENV
             source $BASH_ENV
   restore_parameter_cache:
     steps:
       - restore_cache:
           key: cargo-v4b-{{ checksum "paramfetch-checksum.txt" }}
           paths:
-            - /root/.filecoin-parameter-cache
+            - /tmp/filecoin-parameter-cache
   restore_rust_cache:
     steps:
       - restore_cache:
@@ -309,11 +307,11 @@ commands:
       - save_cache:
           key: cargo-v4b-{{ checksum "paramfetch-checksum.txt" }}
           paths:
-            - /root/.filecoin-parameter-cache
+            - /tmp/filecoin-parameter-cache
   save_rust_cache:
     steps:
       - save_cache:
           key: cargo-v4b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
           paths:
-            - /root/.cargo
-            - /root/.rustup
+            - /tmp/cargo
+            - /tmp/rustup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,7 @@ jobs:
       - run:
           name: Calculate dependencies
           command: cargo generate-lockfile
-      - restore_cache:
-          keys:
-            - cargo-v4b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+      - restore_rust_cache
       - run: rustup install $(cat rust-toolchain)
       - run: rustup default $(cat rust-toolchain)
       - run: rustup component add rustfmt-preview
@@ -29,19 +27,21 @@ jobs:
             # install paramfetch
             cargo install filecoin-proofs --force --git=https://github.com/filecoin-project/rust-fil-proofs.git --branch=master
             which paramcache || { printf '%s\n' "missing paramcache binary" >&2; exit 1; }
-
-            # compute and cache Groth parameters for all sector sizes
-            paramcache
+      - run:
+          name: create paramfetch checksum
+          command: md5sum $(which paramfetch) | cut -d ' ' -f 1 >> paramfetch-checksum.txt
+      - restore_parameter_cache
+      - run:
+          name: Generate Groth parameters and verifying keys
+          command: paramcache
       - persist_to_workspace:
           root: "."
           paths:
             - Cargo.lock
-      - save_cache:
-          key: cargo-v4b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
-          paths:
-            - /root/.cargo
-            - /root/.rustup
-            - /root/.filecoin-parameter-cache
+            - paramfetch-checksum.txt
+      - save_parameter_cache
+      - save_rust_cache
+
   test:
     docker:
       - image: filecoin/rust:latest
@@ -52,9 +52,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: "."
-      - restore_cache:
-          keys:
-            - cargo-v4b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+      - restore_rust_cache
       - run:
           name: Test (stable)
           command: cargo +stable test --verbose --all
@@ -80,9 +78,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: "."
-      - restore_cache:
-          keys:
-            - cargo-v4b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+      - restore_rust_cache
       - run:
           name: Test (stable) in release profile
           command: |
@@ -103,9 +99,8 @@ jobs:
       - checkout
       - attach_workspace:
           at: "."
-      - restore_cache:
-          keys:
-            - cargo-v4b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+      - restore_parameter_cache
+      - restore_rust_cache
       - run:
           name: Build the static lib for linking into the example
           command: ./scripts/build-release.sh $(cat ./rust-toolchain) --verbose --package sector-builder-ffi
@@ -123,9 +118,8 @@ jobs:
       - checkout
       - attach_workspace:
           at: "."
-      - restore_cache:
-          keys:
-            - cargo-v4b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+      - restore_parameter_cache
+      - restore_rust_cache
       - run:
           name: Test (stable) in release profile
           command: cargo +stable test --verbose --release --all -- --ignored
@@ -140,9 +134,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: "."
-      - restore_cache:
-          keys:
-            - cargo-v4b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+      - restore_rust_cache
       - run:
           name: Test (nightly)
           command: cargo +$(cat rust-toolchain) test --verbose --all
@@ -158,9 +150,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: "."
-      - restore_cache:
-          keys:
-            - cargo-v4b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+      - restore_rust_cache
       - run:
           name: Benchmarks (nightly)
           command: cargo +$(cat rust-toolchain) build --benches --verbose --all
@@ -176,9 +166,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: "."
-      - restore_cache:
-          keys:
-            - cargo-v4b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+      - restore_rust_cache
       - run:
           name: Run cargo fmt
           command: cargo fmt --all -- --check
@@ -193,9 +181,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: "."
-      - restore_cache:
-          keys:
-            - cargo-v4b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+      - restore_rust_cache
       - run:
           name: Run cargo clippy
           command: cargo clippy --all
@@ -210,9 +196,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: "."
-      - restore_cache:
-          keys:
-            - cargo-v4b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+      - restore_rust_cache
       - run:
           name: Install jq
           command: apt-get install jq -yqq
@@ -310,3 +294,26 @@ commands:
             echo 'export FILECOIN_PARAMETER_CACHE="/root/.filecoin-parameter-cache"' >> $BASH_ENV
             echo 'export RUST_BACKTRACE=1' >> $BASH_ENV
             source $BASH_ENV
+  restore_parameter_cache:
+    steps:
+      - restore_cache:
+          key: cargo-v4b-{{ checksum "paramfetch-checksum.txt" }}
+          paths:
+            - /root/.filecoin-parameter-cache
+  restore_rust_cache:
+    steps:
+      - restore_cache:
+          key: cargo-v4b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+  save_parameter_cache:
+    steps:
+      - save_cache:
+          key: cargo-v4b-{{ checksum "paramfetch-checksum.txt" }}
+          paths:
+            - /root/.filecoin-parameter-cache
+  save_rust_cache:
+    steps:
+      - save_cache:
+          key: cargo-v4b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+          paths:
+            - /root/.cargo
+            - /root/.rustup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           command: cargo generate-lockfile
       - restore_cache:
           keys:
-            - cargo-v4-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v4b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - run: rustup install $(cat rust-toolchain)
       - run: rustup default $(cat rust-toolchain)
       - run: rustup component add rustfmt-preview
@@ -30,14 +30,14 @@ jobs:
             cargo install filecoin-proofs --force --git=https://github.com/filecoin-project/rust-fil-proofs.git --branch=master
             which paramcache || { printf '%s\n' "missing paramcache binary" >&2; exit 1; }
 
-            # compute and cache Groth parameters for 1KiB sectors
-            paramcache --test-only
+            # compute and cache Groth parameters for all sector sizes
+            paramcache
       - persist_to_workspace:
           root: "."
           paths:
             - Cargo.lock
       - save_cache:
-          key: cargo-v4-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+          key: cargo-v4b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
           paths:
             - /root/.cargo
             - /root/.rustup
@@ -54,7 +54,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v4-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v4b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - run:
           name: Test (stable)
           command: cargo +stable test --verbose --all
@@ -82,7 +82,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v4-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v4b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - run:
           name: Test (stable) in release profile
           command: |
@@ -101,7 +101,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v4-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v4b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - run:
           name: Build the static lib for linking into the example
           command: ./scripts/build-release.sh $(cat ./rust-toolchain) --verbose --package sector-builder-ffi
@@ -121,7 +121,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v4-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v4b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - run:
           name: Test (stable) in release profile
           command: cargo +stable test --verbose --release --all -- --ignored
@@ -138,7 +138,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v4-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v4b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - run:
           name: Test (nightly)
           command: cargo +$(cat rust-toolchain) test --verbose --all
@@ -156,7 +156,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v4-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v4b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - run:
           name: Benchmarks (nightly)
           command: cargo +$(cat rust-toolchain) build --benches --verbose --all
@@ -174,7 +174,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v4-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v4b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - run:
           name: Run cargo fmt
           command: cargo fmt --all -- --check
@@ -191,7 +191,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v4-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v4b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - run:
           name: Run cargo clippy
           command: cargo clippy --all
@@ -208,7 +208,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v4-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v4b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - run:
           name: Install jq
           command: apt-get install jq -yqq

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,23 +308,23 @@ commands:
   restore_parameter_cache:
     steps:
       - restore_cache:
-          key: cargo-v4b-{{ checksum "paramfetch-checksum.txt" }}
+          key: cargo-v4c-{{ checksum "paramfetch-checksum.txt" }}
           paths:
             - /tmp/filecoin-parameter-cache
   restore_rust_cache:
     steps:
       - restore_cache:
-          key: cargo-v4b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+          key: cargo-v4c-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
   save_parameter_cache:
     steps:
       - save_cache:
-          key: cargo-v4b-{{ checksum "paramfetch-checksum.txt" }}
+          key: cargo-v4c-{{ checksum "paramfetch-checksum.txt" }}
           paths:
             - /tmp/filecoin-parameter-cache
   save_rust_cache:
     steps:
       - save_cache:
-          key: cargo-v4b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+          key: cargo-v4c-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
           paths:
             - /tmp/cargo
             - /tmp/rustup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,6 +252,22 @@ jobs:
 
 workflows:
   version: 2
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 2 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - obtain_parameters
+      - cargo_fetch
+      - ffi_regression:
+          use_256M_sector_size: true
+          requires:
+            - cargo_fetch
+            - obtain_parameters
   test_all:
     jobs:
       - obtain_parameters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
           name: Ensure cache is hydrated with PoRep and PoSt Groth parameters (for test)
           command: |
             # install paramfetch
-            cargo install filecoin-proofs --force --git=https://github.com/filecoin-project/rust-fil-proofs.git --branch=master
+            cargo install filecoin-proofs --bin=paramcache --force --git=https://github.com/filecoin-project/rust-fil-proofs.git --branch=master
             which paramcache || { printf '%s\n' "missing paramcache binary" >&2; exit 1; }
       - run:
           name: create paramfetch checksum

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,22 +252,6 @@ jobs:
 
 workflows:
   version: 2
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 2 * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - obtain_parameters
-      - cargo_fetch
-      - ffi_regression:
-          use_256M_sector_size: true
-          requires:
-            - cargo_fetch
-            - obtain_parameters
   test_all:
     jobs:
       - obtain_parameters
@@ -286,6 +270,17 @@ workflows:
           requires:
             - cargo_fetch
             - obtain_parameters
+          filters:
+            branches:
+              ignore: master
+      - ffi_regression:
+          use_256M_sector_size: true
+          requires:
+            - cargo_fetch
+            - obtain_parameters
+          filters:
+            branches:
+              only: master
       - test_ignored_release:
           requires:
             - cargo_fetch


### PR DESCRIPTION
Fixes #41 

## Why does this PR exist?

We have no automated tests in any project which run through the storage protocol (from the perspective of the Rust software) using the 256MiB sector size.

## What's in this PR?

This changeset runs the FFI test suite (bin packing, sealing and verifying two sectors, health checks, PoSt generation, storage faults) for 256MiB sectors on every commit to `master`.