### PR TITLE
ci(install jq to directory on path)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,9 +237,8 @@ jobs:
       - run:
           name: Install jq
           command: |
-            mkdir $HOME/.bin
-            curl --location https://github.com/stedolan/jq/releases/download/jq-1.6/jq-osx-amd64 --output $HOME/.bin/jq
-            chmod +x $HOME/.bin/jq
+            HOMEBREW_NO_AUTO_UPDATE=1 brew install jq
+            jq --version
       - run:
           name: Build the release
           command: ./scripts/build-release.sh $(cat ./rust-toolchain) --verbose --all


### PR DESCRIPTION
## Why does this PR exist?

`jq` is required by the release packaging script. The location to which it was installed wasn't on the path, so the `jq` invocation failed.

## What's in this PR?

This PR installs `jq` using Homebrew, which ensures that it's on the path.