### PR TITLE
Feat/47 paramcache to release tarball

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,7 +295,7 @@ workflows:
             - cargo_fetch
           filters:
             branches:
-              only: master
+              ignore: master
       - build_darwin_release:
           create_github_release: false
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,7 +295,7 @@ workflows:
             - cargo_fetch
           filters:
             branches:
-              ignore: master
+              only: master
       - build_darwin_release:
           create_github_release: false
           requires:
@@ -303,13 +303,6 @@ workflows:
           filters:
             branches:
               ignore: master
-      - build_darwin_release:
-          create_github_release: true
-          requires:
-            - cargo_fetch
-          filters:
-            branches:
-              only: master
 
 commands:
   configure_env:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,6 +230,7 @@ jobs:
       - configure_env
       - install_rust
       - checkout
+      - restore_rust_cache
       - run: rustup install $(cat rust-toolchain)
       - run: rustup default $(cat rust-toolchain)
       - run: cargo update

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,23 +319,23 @@ commands:
   restore_parameter_cache:
     steps:
       - restore_cache:
-          key: cargo-v4c-{{ checksum "paramfetch-checksum.txt" }}
+          key: cargo-v4d-{{ checksum "paramfetch-checksum.txt" }}
           paths:
             - /tmp/filecoin-parameter-cache
   restore_rust_cache:
     steps:
       - restore_cache:
-          key: cargo-v4c-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+          key: cargo-v4d-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
   save_parameter_cache:
     steps:
       - save_cache:
-          key: cargo-v4c-{{ checksum "paramfetch-checksum.txt" }}
+          key: cargo-v4d-{{ checksum "paramfetch-checksum.txt" }}
           paths:
             - /tmp/filecoin-parameter-cache
   save_rust_cache:
     steps:
       - save_cache:
-          key: cargo-v4c-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+          key: cargo-v4d-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
           paths:
             - /tmp/cargo
             - /tmp/rustup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,12 +297,9 @@ workflows:
             branches:
               only: master
       - build_darwin_release:
-          create_github_release: false
+          create_github_release: true
           requires:
             - cargo_fetch
-          filters:
-            branches:
-              ignore: master
 
 commands:
   configure_env:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -307,13 +307,14 @@ commands:
       - run:
           name: Configure environment variables
           command: |
-            echo 'export RUST_LOG=info' >> $BASH_ENV
-            echo 'export FILECOIN_PARAMETER_CACHE="/tmp/filecoin-parameter-cache"' >> $BASH_ENV
-            echo 'export RUST_BACKTRACE=1' >> $BASH_ENV
             echo 'export CARGO_HOME=/tmp/cargo' >> $BASH_ENV
-            echo 'export RUSTUP_HOME=/tmp/rustup' >> $BASH_ENV
+            echo 'export CARGO_TARGET_DIR=/tmp/cargo-target' >> $BASH_ENV
             echo 'export CIRCLE_ARTIFACTS=/tmp/circle-ci-artifacts' >> $BASH_ENV
+            echo 'export FILECOIN_PARAMETER_CACHE="/tmp/filecoin-parameter-cache"' >> $BASH_ENV
             echo 'export PATH="${CARGO_HOME}/bin:${PATH}"' >> $BASH_ENV
+            echo 'export RUST_BACKTRACE=1' >> $BASH_ENV
+            echo 'export RUST_LOG=info' >> $BASH_ENV
+            echo 'export RUSTUP_HOME=/tmp/rustup' >> $BASH_ENV
             source $BASH_ENV
   restore_parameter_cache:
     steps:
@@ -338,6 +339,7 @@ commands:
           paths:
             - /tmp/cargo
             - /tmp/rustup
+            - /tmp/cargo-target
   install_rust:
     steps:
       - run:

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -9,6 +9,14 @@ then
 fi
 
 build_output_tmp=$(mktemp)
+linker_flag_cache=./target/release/linker-flags
+
+# respect CARGO_TARGET_DIR, if set
+#
+if [[ ! -z "$CARGO_TARGET_DIR" ]]; then
+    (>&2 echo "CARGO_TARGET_DIR set to ${CARGO_TARGET_DIR}")
+    linker_flag_cache="${CARGO_TARGET_DIR}/release/linker-flags"
+fi
 
 # clean up temp file on exit
 #
@@ -31,10 +39,10 @@ linker_flags=$(cat ${build_output_tmp} \
 # to read them from output dir if not
 #
 if [[ -z "$linker_flags" ]]; then
-    linker_flags=$(cat ./target/release/linker-flags)
+    linker_flags=$(cat "${linker_flag_cache}")
     (>&2 echo "falling back to cached linker flags")
 else
-    echo "${linker_flags}" > ./target/release/linker-flags
+    echo "${linker_flags}" > "${linker_flag_cache}"
 fi
 
 # eject from build script if we don't have linker flags for our pkg-config file

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -Ee
+set -Eex
 
 if [[ -z "$1" ]]
 then

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -9,13 +9,13 @@ then
 fi
 
 build_output_tmp=$(mktemp)
-linker_flag_cache=./target/release/linker-flags
+target_dir="./target"
 
 # respect CARGO_TARGET_DIR, if set
 #
 if [[ ! -z "$CARGO_TARGET_DIR" ]]; then
     (>&2 echo "CARGO_TARGET_DIR set to ${CARGO_TARGET_DIR}")
-    linker_flag_cache="${CARGO_TARGET_DIR}/release/linker-flags"
+    target_dir=$CARGO_TARGET_DIR
 fi
 
 # clean up temp file on exit
@@ -39,10 +39,10 @@ linker_flags=$(cat ${build_output_tmp} \
 # to read them from output dir if not
 #
 if [[ -z "$linker_flags" ]]; then
-    linker_flags=$(cat "${linker_flag_cache}")
+    linker_flags=$(cat "${target_dir}/release/linker-flags")
     (>&2 echo "falling back to cached linker flags")
 else
-    echo "${linker_flags}" > "${linker_flag_cache}"
+    echo "${linker_flags}" > "${target_dir}/release/linker-flags"
 fi
 
 # eject from build script if we don't have linker flags for our pkg-config file
@@ -59,8 +59,8 @@ sed -e "s;@VERSION@;$(git rev-parse HEAD);" \
 
 # ensure header file was built
 #
-find . -type f -name sector_builder_ffi.h | read
+find "${target_dir}" -type f -name sector_builder_ffi.h | read
 
 # ensure the archive file was built
 #
-find . -type f -name libsector_builder_ffi.a | read
+find "${target_dir}" -type f -name libsector_builder_ffi.a | read

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -20,7 +20,7 @@ find . -type f -name libsector_builder_ffi.a -exec cp -- "{}" $TAR_PATH/lib/ \;
 find . -type f -name sector_builder_ffi.pc -exec cp -- "{}" $TAR_PATH/lib/pkgconfig/ \;
 
 cargo install filecoin-proofs \
-  --bin paramfetch \
+  --bin paramcache \
   --force \
   --git=https://github.com/filecoin-project/rust-fil-proofs.git \
   --branch=master \

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -2,6 +2,15 @@
 
 set -e
 
+target_dir="./target"
+
+# respect CARGO_TARGET_DIR, if set
+#
+if [[ ! -z "$CARGO_TARGET_DIR" ]]; then
+    (>&2 echo "CARGO_TARGET_DIR set to ${CARGO_TARGET_DIR}")
+    target_dir=$CARGO_TARGET_DIR
+fi
+
 if [ -z "$1" ]; then
   TAR_FILE=`mktemp`.tar.gz
 else
@@ -15,9 +24,9 @@ mkdir -p $TAR_PATH/bin
 mkdir -p $TAR_PATH/include
 mkdir -p $TAR_PATH/lib/pkgconfig
 
-find . -type f -name sector_builder_ffi.h -exec cp -- "{}" $TAR_PATH/include/ \;
-find . -type f -name libsector_builder_ffi.a -exec cp -- "{}" $TAR_PATH/lib/ \;
-find . -type f -name sector_builder_ffi.pc -exec cp -- "{}" $TAR_PATH/lib/pkgconfig/ \;
+find "${target_dir}" -type f -name sector_builder_ffi.h -exec cp -- "{}" $TAR_PATH/include/ \;
+find "${target_dir}" -type f -name libsector_builder_ffi.a -exec cp -- "{}" $TAR_PATH/lib/ \;
+find "${target_dir}" -type f -name sector_builder_ffi.pc -exec cp -- "{}" $TAR_PATH/lib/pkgconfig/ \;
 
 cargo install filecoin-proofs \
   --bin paramcache \


### PR DESCRIPTION
Fixes #47 

Fixes [this user-reported bug](https://github.com/filecoin-project/go-filecoin/issues/3174).

## Why does this PR exist?

`paramfetch` isn't working for us (issues with ipget), so we're replacing it with `paramcache`.

Also, the `install-rust-fil-sector-builder` script would fail after a previously-successful run.

## What's in this PR?

1. Add `paramcache` to release tarball
1. Use cached linker flags if available