### PR TITLE
fix(kvstore): ensure put is flushed to disk before returning

### DIFF
--- a/sector-builder/src/kv_store/sled.rs
+++ b/sector-builder/src/kv_store/sled.rs
@@ -17,6 +17,7 @@ impl KeyValueStore for SledKvs {
 
     fn put(&self, key: &[u8], value: &[u8]) -> Result<()> {
         self.db.set(key, value)?;
+        let _ = self.db.flush()?;
         Ok(())
     }
 


### PR DESCRIPTION
## Why is this PR needed?

I am running some tests (in a different branch) which fork a sector builder, begin sealing, and then kill/wait the forked child. I have noticed that sector metadata snapshots have not been persisted to disk (after add_piece and before seal completes), which means that the next sector builder I initialize isn't able to resume where the previous one left off.

## What's in this PR?

This PR flushes sled's store to disk on each `put`.