### PR TITLE
sector builder must recover from impolite shutdown

### DIFF
--- a/sector-builder-ffi/Cargo.toml
+++ b/sector-builder-ffi/Cargo.toml
@@ -32,6 +32,8 @@ scopeguard = "1.0"
 byteorder = "1.3.1"
 tempfile = "3.0.8"
 rand = "0.6.5"
+nix = "0.9.0"
+pipe-channel = "1.2.2"
 
 [build-dependencies]
 bindgen = "0.49"

--- a/sector-builder/src/builder.rs
+++ b/sector-builder/src/builder.rs
@@ -101,7 +101,7 @@ impl<R: 'static + Send + std::io::Read> SectorBuilder<R> {
             sector_size,
         };
 
-        let scheduler = Scheduler::start(scheduler_tx.clone(), scheduler_rx, worker_tx.clone(), m);
+        let scheduler = Scheduler::start(scheduler_tx.clone(), scheduler_rx, worker_tx.clone(), m)?;
 
         Ok(SectorBuilder {
             scheduler_tx,


### PR DESCRIPTION
Fixes #17 

## Why does this PR exist?

If a sector builder is killed after sealing begins for a staged sector S, its last-persisted snapshot will show S with a status of "Sealing." When sector builder is restarted, we need to restart sealing for S.

## What's in this PR?

This PR adds software to the sector builder which, on start, checks to see if any of its sectors were last marked as "Sealing." If they were, it schedules seal tasks for each of those sectors in the worker queue.

It also adds a test which demonstrates this new recovery behavior by forking a sector builder which begins sealing before receiving a SIGKILL. The next sector builder picks up where the previous left off.

cc @whyrusleeping 