### PR TITLE
refactor: use custom failure errors only

### DIFF
--- a/sector-builder/Cargo.toml
+++ b/sector-builder/Cargo.toml
@@ -26,7 +26,11 @@ log = "0.4.7"
 rayon = "1.1.0"
 
 [dependencies.sled]
-version = "0.24"
+# Upgrade to at least version 0.29 once it is released. This new version is needed for the error
+# handling
+#version = "0.29"
+git = "https://github.com/spacejam/sled"
+rev = "7d01393b65330c6ce8d1492014a673e61bce5429"
 optional = true
 
 [dev-dependencies]

--- a/sector-builder/src/helpers/add_piece.rs
+++ b/sector-builder/src/helpers/add_piece.rs
@@ -51,10 +51,10 @@ pub fn add_piece<S: SectorStore>(
             .map_err(Into::into)
             .and_then(|num_bytes_written| {
                 if num_bytes_written != expected_num_bytes_written {
-                    Err(
-                        err_inc_write(u64::from(num_bytes_written), u64::from(piece_bytes_len))
-                            .into(),
-                    )
+                    Err(err_inc_write(
+                        u64::from(num_bytes_written),
+                        u64::from(piece_bytes_len),
+                    ))
                 } else {
                     Ok(s.sector_id)
                 }
@@ -70,7 +70,7 @@ pub fn add_piece<S: SectorStore>(
                 sector_id
             })
     } else {
-        Err(err_unrecov("unable to retrieve sector from state-map").into())
+        Err(err_unrecov("unable to retrieve sector from state-map"))
     }
 }
 
@@ -82,7 +82,10 @@ fn compute_destination_sector_id(
     num_bytes_in_piece: UnpaddedBytesAmount,
 ) -> Result<Option<SectorId>> {
     if num_bytes_in_piece > max_bytes_per_sector {
-        Err(err_overflow(num_bytes_in_piece.into(), max_bytes_per_sector.into()).into())
+        Err(err_overflow(
+            num_bytes_in_piece.into(),
+            max_bytes_per_sector.into(),
+        ))
     } else {
         let mut vector = candidate_sectors.to_vec();
         vector.sort_by(|a, b| a.sector_id.cmp(&b.sector_id));

--- a/sector-builder/src/helpers/get_seal_status.rs
+++ b/sector-builder/src/helpers/get_seal_status.rs
@@ -18,7 +18,7 @@ pub fn get_seal_status(
                 .get(&sector_id)
                 .and_then(|staged_sector| Some(staged_sector.seal_status.clone()))
         })
-        .ok_or_else(|| err_unrecov(format!("no sector with id {} found", sector_id)).into())
+        .ok_or_else(|| err_unrecov(format!("no sector with id {} found", sector_id)))
 }
 
 #[cfg(test)]

--- a/sector-builder/src/helpers/get_sealed_sector_health.rs
+++ b/sector-builder/src/helpers/get_sealed_sector_health.rs
@@ -1,3 +1,4 @@
+use crate::error::Result;
 use crate::helpers;
 use crate::{SealedSectorHealth, SealedSectorMetadata};
 use std::path::Path;
@@ -5,7 +6,7 @@ use std::path::Path;
 pub fn get_sealed_sector_health<T: AsRef<Path>>(
     sealed_sector_path: T,
     meta: &SealedSectorMetadata,
-) -> Result<SealedSectorHealth, failure::Error> {
+) -> Result<SealedSectorHealth> {
     let result = std::fs::metadata(&sealed_sector_path);
 
     // ensure that the file still exists

--- a/sector-builder/src/helpers/snapshots.rs
+++ b/sector-builder/src/helpers/snapshots.rs
@@ -26,8 +26,8 @@ pub fn load_snapshot<T: KeyValueStore>(
     let result: Option<Vec<u8>> = kv_store.get(&Vec::from(key))?;
 
     if let Some(val) = result {
-        return serde_cbor::from_slice(&val[..])
-            .map_err(failure::Error::from)
+        return serde_cbor::from_slice::<SectorBuilderState>(&val[..])
+            .map_err(From::from)
             .map(Option::Some);
     }
 

--- a/sector-builder/src/worker.rs
+++ b/sector-builder/src/worker.rs
@@ -3,7 +3,7 @@ use std::thread;
 
 use filecoin_proofs::error::ExpectWithBacktrace;
 
-use crate::error::Result;
+use crate::error::{self, Result};
 use crate::scheduler::SchedulerTask;
 use crate::{PoRepConfig, UnpaddedByteIndex, UnpaddedBytesAmount};
 use std::path::PathBuf;
@@ -144,7 +144,8 @@ impl Worker {
                         &prover_id,
                         sector_id,
                         &piece_lens,
-                    );
+                    )
+                    .map_err(error::err_filecoin_proofs);
 
                     done_tx
                         .send(SchedulerTask::HandleSealResult(
@@ -174,6 +175,7 @@ impl Worker {
                         piece_start_byte,
                         piece_len,
                     )
+                    .map_err(error::err_filecoin_proofs)
                     .map(|num_bytes_unsealed| (num_bytes_unsealed, destination_path));
 
                     done_tx


### PR DESCRIPTION
Instead of having a catch-all `failure:Error` error that can be downcasted
to a specific one, have custom errors for all errors that can happen. This
way you have full control and using the `failure` library doesn't directly
bleed into the public API.

In the future `failure` could possible be replaced with standard errors
without causing too much pain for users of this library.
