### PR TITLE
refactor(sector-builder-ffi): use FCPResponseStatus from ffi-toolkit

### DIFF
--- a/sector-builder-ffi/cbindgen.toml
+++ b/sector-builder-ffi/cbindgen.toml
@@ -20,4 +20,4 @@ prefix = "sector_builder_ffi_"
 
 [parse]
 parse_deps = true
-include = ["sector-builder", "filecoin-proofs-ffi", "filedescriptors"]
+include = ["sector-builder", "ffi-toolkit", "filecoin-proofs-ffi", "filedescriptors"]

--- a/sector-builder-ffi/src/api.rs
+++ b/sector-builder-ffi/src/api.rs
@@ -2,16 +2,14 @@ use std::mem;
 use std::ptr;
 use std::slice::from_raw_parts;
 
-use ffi_toolkit::rust_str_to_c_str;
-use ffi_toolkit::{c_str_to_rust_str, raw_ptr};
+use ffi_toolkit::{c_str_to_rust_str, raw_ptr, rust_str_to_c_str, FCPResponseStatus};
 use libc;
 use once_cell::sync::OnceCell;
 use sector_builder::{GetSealedSectorResult, PieceMetadata, SealStatus, SecondsSinceEpoch};
 use storage_proofs::sector::SectorId;
 
 use crate::responses::{
-    self, err_code_and_msg, FCPResponseStatus, FFIPieceMetadata, FFISealStatus,
-    FFISealedSectorHealth,
+    self, err_code_and_msg, FFIPieceMetadata, FFISealStatus, FFISealedSectorHealth,
 };
 
 #[repr(C)]

--- a/sector-builder-ffi/src/responses.rs
+++ b/sector-builder-ffi/src/responses.rs
@@ -4,7 +4,7 @@ use std::ptr;
 
 use drop_struct_macro_derive::DropStructMacro;
 use failure::Error;
-use ffi_toolkit::free_c_str;
+use ffi_toolkit::{free_c_str, FCPResponseStatus};
 use libc;
 use sector_builder::{SealedSectorHealth, SectorBuilderErr, SectorManagerErr};
 
@@ -29,16 +29,6 @@ impl From<SealedSectorHealth> for FFISealedSectorHealth {
             SealedSectorHealth::ErrorMissing => FFISealedSectorHealth::ErrorMissing,
         }
     }
-}
-
-#[repr(C)]
-#[derive(PartialEq, Debug)]
-pub enum FCPResponseStatus {
-    // Don't use FCPSuccess, since that complicates description of 'successful' verification.
-    FCPNoError = 0,
-    FCPUnclassifiedError = 1,
-    FCPCallerError = 2,
-    FCPReceiverError = 3,
 }
 
 #[repr(C)]


### PR DESCRIPTION
ffi-toolkit now contains the `FCPResponseStatus` enum, so that it can be used
from all Filecoin FFIs. With this commit we also use this central instance
in sectore-builder-ffi.

This one needs https://github.com/filecoin-project/rust-fil-ffi-toolkit/pull/2.