### PR TITLE
feat(stacked drg): update to conform to new stacked DRG+ API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,14 +10,13 @@ jobs:
       - configure_env
       - install_rust
       - run:
-          name: Install paramfetch from head of rust-fil-proofs master branch
+          name: Install paramcache from head of rust-fil-proofs master branch
           command: |
-            # install paramfetch
             cargo install filecoin-proofs --bin=paramcache --force --git=https://github.com/filecoin-project/rust-fil-proofs.git --branch=master
             which paramcache || { printf '%s\n' "missing paramcache binary" >&2; exit 1; }
       - run:
           name: create paramfetch checksum
-          command: md5sum $(which paramfetch) | cut -d ' ' -f 1 >> paramfetch-checksum.txt
+          command: md5sum $(which paramcache) | cut -d ' ' -f 1 >> paramcache-checksum.txt
       - restore_parameter_cache
       - run:
           name: Generate Groth parameters and verifying keys
@@ -25,7 +24,7 @@ jobs:
       - persist_to_workspace:
           root: "."
           paths:
-            - paramfetch-checksum.txt
+            - paramcache-checksum.txt
       - save_parameter_cache
 
   cargo_fetch:
@@ -322,7 +321,7 @@ commands:
   restore_parameter_cache:
     steps:
       - restore_cache:
-          key: v1-proof-params-{{ checksum "paramfetch-checksum.txt" }}
+          key: v2-proof-params-{{ checksum "paramcache-checksum.txt" }}
           paths:
             - /tmp/filecoin-parameter-cache
   restore_rust_cache:
@@ -332,7 +331,7 @@ commands:
   save_parameter_cache:
     steps:
       - save_cache:
-          key: v1-proof-params-{{ checksum "paramfetch-checksum.txt" }}
+          key: v2-proof-params-{{ checksum "paramcache-checksum.txt" }}
           paths:
             - /tmp/filecoin-parameter-cache
   save_rust_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     docker:
       - image: filecoin/rust:latest
     working_directory: /mnt/crate
-    resource_class: xlarge
+    resource_class: 2xlarge+
     steps:
       - configure_env
       - install_rust

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,6 @@ jobs:
       - run:
           name: Generate Groth parameters and verifying keys
           command: paramcache
-      - persist_to_workspace:
-          root: "."
       - save_parameter_cache
 
   cargo_fetch:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,6 @@ jobs:
           command: |
             cargo install filecoin-proofs --bin=paramcache --force --git=https://github.com/filecoin-project/rust-fil-proofs.git --branch=master
             which paramcache || { printf '%s\n' "missing paramcache binary" >&2; exit 1; }
-      - run:
-          name: create paramfetch checksum
-          command: md5sum $(which paramcache) | cut -d ' ' -f 1 >> paramcache-checksum.txt
       - restore_parameter_cache
       - run:
           name: Generate Groth parameters and verifying keys
@@ -321,7 +318,7 @@ commands:
   restore_parameter_cache:
     steps:
       - restore_cache:
-          key: v2-proof-params-{{ checksum "paramcache-checksum.txt" }}
+          key: v14-proof-params
           paths:
             - /tmp/filecoin-parameter-cache
   restore_rust_cache:
@@ -331,7 +328,7 @@ commands:
   save_parameter_cache:
     steps:
       - save_cache:
-          key: v2-proof-params-{{ checksum "paramcache-checksum.txt" }}
+          key: v14-proof-params
           paths:
             - /tmp/filecoin-parameter-cache
   save_rust_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,6 @@ jobs:
           command: paramcache
       - persist_to_workspace:
           root: "."
-          paths:
-            - paramcache-checksum.txt
       - save_parameter_cache
 
   cargo_fetch:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,10 +62,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "arrayvec"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -189,7 +189,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "constant_time_eq 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -199,7 +199,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "constant_time_eq 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -272,7 +272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -521,7 +521,7 @@ name = "crossbeam-epoch"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -565,6 +565,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "ctor"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "digest"
@@ -705,7 +719,7 @@ dependencies = [
 [[package]]
 name = "filecoin-proofs"
 version = "0.6.4"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs.git#64ece8751042bf7f6840efa5a27b7ea449bd1acb"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs.git#681fb6b68e02947eb2036ddb83dbf4db8f419f7f"
 dependencies = [
  "bellperson 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitvec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -731,7 +745,7 @@ dependencies = [
  "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_cbor 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -743,7 +757,7 @@ dependencies = [
 [[package]]
 name = "filecoin-proofs-ffi"
 version = "0.7.3"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs-ffi.git#d600fd2c25bae0e57c23832370a8280b84e5fe42"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs-ffi.git#91aafced59e3508bcb38e761a9346017e48bf793"
 dependencies = [
  "cbindgen 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "drop_struct_macro_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -956,7 +970,7 @@ dependencies = [
  "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1012,11 +1026,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "iovec"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1166,7 +1179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1197,7 +1210,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "schannel 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "security-framework 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "security-framework-sys 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1240,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "nodrop"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1323,7 +1336,7 @@ dependencies = [
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.51 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1341,7 +1354,7 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.50"
+version = "0.9.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1358,6 +1371,14 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "output_vt100"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1487,6 +1508,17 @@ dependencies = [
 name = "ppv-lite86"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "pretty_assertions"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ctor 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "output_vt100 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "pretty_env_logger"
@@ -1786,7 +1818,7 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.9.21"
+version = "0.9.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1905,7 +1937,7 @@ dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "pipe-channel 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2071,7 +2103,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "storage-proofs"
 version = "0.6.2"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs.git#64ece8751042bf7f6840efa5a27b7ea449bd1acb"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs.git#681fb6b68e02947eb2036ddb83dbf4db8f419f7f"
 dependencies = [
  "aes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2084,6 +2116,7 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "config 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2099,6 +2132,7 @@ dependencies = [
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "paired 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pbr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2312,12 +2346,12 @@ dependencies = [
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-sync 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-sync 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tokio-sync"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2331,7 +2365,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2618,7 +2652,7 @@ dependencies = [
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08abcc3b4e9339e33a3d0a5ed15d84a687350c05689d825e0f6655eef9e76a94"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
-"checksum arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d73f9beda665eaa98ab9e4f7442bd4e7de6652587de55b2525e52e29c1b0ba"
+"checksum arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
 "checksum backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)" = "690a62be8920ccf773ee00ef0968649b0e724cda8bd5b12286302b4ae955fdf5"
@@ -2672,6 +2706,8 @@ dependencies = [
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum csv 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "37519ccdfd73a75821cac9319d4fce15a81b9fcf75f951df5b9988aa3a0af87d"
 "checksum csv-core 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9b5cadb6b25c77aeff80ba701712494213f4a8418fcda2ee11b6560c3ad0bf4c"
+"checksum ctor 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "cd8ce37ad4184ab2ce004c33bf6379185d3b1c95801cab51026bd271bf68eedc"
+"checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum drop_struct_macro_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "104ad390ab213ccf440be08d933293135f7aaf9bfc4203fecce430eeef8d6a50"
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
@@ -2718,7 +2754,7 @@ dependencies = [
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum indexmap 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a61202fbe46c4a951e9404a720a0180bcf3212c750d735cb5c4ba4dc551299f3"
-"checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
+"checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 "checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
@@ -2744,7 +2780,7 @@ dependencies = [
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nix 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b7fd5681d13fda646462cfbd4e5f2051279a89a544d50eb98c365b507246839f"
 "checksum nix 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a2c5afeb0198ec7be8569d666644b574345aad2e95a53baf3a532da3e0f3fb32"
-"checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
+"checksum nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 "checksum num-bigint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f9c3f34cdd24f334cb265d9bf8bfa8a241920d026916785747a92f0e55541a1a"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
@@ -2757,8 +2793,9 @@ dependencies = [
 "checksum openssl 0.10.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2f372b2b53ce10fb823a337aaa674e3a7d072b957c6264d0f4ff0bd86e657449"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-src 111.6.0+1.1.1d (registry+https://github.com/rust-lang/crates.io-index)" = "b9c2da1de8a7a3f860919c01540b03a6db16de042405a8a07a5e9d0b4b825d9c"
-"checksum openssl-sys 0.9.50 (registry+https://github.com/rust-lang/crates.io-index)" = "2c42dcccb832556b5926bc9ae61e8775f2a61e725ab07ab3d1e7fcf8ae62c3b6"
+"checksum openssl-sys 0.9.51 (registry+https://github.com/rust-lang/crates.io-index)" = "ba24190c8f0805d3bd2ce028f439fe5af1d55882bbe6261bed1dbc93b50dd6b1"
 "checksum os_type 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7edc011af0ae98b7f88cf7e4a83b70a54a75d2b8cb013d6efd02e5956207e9eb"
+"checksum output_vt100 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
 "checksum pagecache 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "74a701d13e2f3ee32a50be43321da8f712cf1e6e9ff0e2be66ab7f5c6598a16a"
 "checksum paired 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)" = "317f455df1cd3ae640f9026be272b5699eb3f44fa18296541b3b49119e2a8c7e"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
@@ -2772,6 +2809,7 @@ dependencies = [
 "checksum pkg-config 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "72d5370d90f49f70bd033c3d75e87fc529fbfff9d6f7cccef07d6170079d91ea"
 "checksum positioned-io 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c405a565f48a728dbb07fa1770e30791b0fa3e6344c1e5615225ce84049354d6"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
+"checksum pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427"
 "checksum pretty_env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "717ee476b1690853d222af4634056d830b5197ffd747726a9a1eee6da9f49074"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "90cf5f418035b98e655e9cdb225047638296b862b42411c4e45bb88d700f7fc0"
@@ -2805,7 +2843,7 @@ dependencies = [
 "checksum regex-automata 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "92b73c2a1770c255c240eaa4ee600df1704a38dc3feaa6e949e7fcd4f8dc09f9"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
-"checksum reqwest 0.9.21 (registry+https://github.com/rust-lang/crates.io-index)" = "02b7e953e14c6f3102b7e8d1f1ee3abf5ecee80b427f5565c9389835cecae95c"
+"checksum reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)" = "2c2064233e442ce85c77231ebd67d9eca395207dec2127fe0bbedde4bd29a650"
 "checksum rgb 0.8.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2089e4031214d129e201f8c3c8c2fe97cd7322478a0d1cdf78e7029b0042efdb"
 "checksum rust-ini 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
@@ -2853,7 +2891,7 @@ dependencies = [
 "checksum tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0f27ee0e6db01c5f0b2973824547ce7e637b2ed79b891a9677b0de9bd532b6ac"
 "checksum tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "5090db468dad16e1a7a54c8c67280c5e4b544f3d3e018f0b913b400261f85926"
 "checksum tokio-reactor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "c56391be9805bc80163151c0b9e5164ee64f4b0200962c346fea12773158f22d"
-"checksum tokio-sync 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2162248ff317e2bc713b261f242b69dbb838b85248ed20bb21df56d60ea4cae7"
+"checksum tokio-sync 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "d06554cce1ae4a50f42fba8023918afa931413aded705b560e29600ccf7c6d76"
 "checksum tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1d14b10654be682ac43efee27401d792507e30fd8d26389e1da3b185de2e4119"
 "checksum tokio-threadpool 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "2bd2c6a3885302581f4401c82af70d792bb9df1700e7437b0aeb4ada94d5388c"
 "checksum tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "f2106812d500ed25a4f38235b9cae8f78a09edf43203e16e59c3b769a342a60e"

--- a/sector-builder-ffi/examples/simple/main.rs
+++ b/sector-builder-ffi/examples/simple/main.rs
@@ -432,7 +432,7 @@ unsafe fn sector_builder_lifecycle(sector_size: u64) -> Result<(), failure::Erro
         );
     }
 
-    // get sealed sector and verify the proof using the first ticket
+    // get sealed sector and verify the proof using the ticket we sealed with
     {
         let sealed_sector = get_sealed_sector(&mut ctx, b_ptr, 124);
 

--- a/sector-builder-ffi/examples/simple/main.rs
+++ b/sector-builder-ffi/examples/simple/main.rs
@@ -180,6 +180,7 @@ unsafe fn kill_restart_recovery(sector_size: u64) -> Result<(), failure::Error> 
         cfg.sector_class,
         cfg.max_num_staged_sectors,
     );
+    defer!(sector_builder_ffi_destroy_sector_builder(ptr));
 
     // block until the sector has sealed
     poll_for_sector_sealing_status(

--- a/sector-builder-ffi/examples/simple/main.rs
+++ b/sector-builder-ffi/examples/simple/main.rs
@@ -350,8 +350,7 @@ unsafe fn sector_builder_lifecycle(sector_size: u64) -> Result<(), failure::Erro
         );
     }
 
-    seal_sector(
-        &mut ctx,
+    seal_sector_nonblocking(
         a_ptr,
         124,
         sector_builder_ffi_FFISealTicket {
@@ -360,8 +359,7 @@ unsafe fn sector_builder_lifecycle(sector_size: u64) -> Result<(), failure::Erro
         },
     );
 
-    seal_sector(
-        &mut ctx,
+    seal_sector_nonblocking(
         a_ptr,
         126,
         sector_builder_ffi_FFISealTicket {

--- a/sector-builder-ffi/examples/simple/main.rs
+++ b/sector-builder-ffi/examples/simple/main.rs
@@ -416,7 +416,7 @@ unsafe fn sector_builder_lifecycle(sector_size: u64) -> Result<(), failure::Erro
                 sealed_sector.comm_d,
                 prover_id,
             ),
-            "seal verification failed  for sector with id 124"
+            "seal verification failed for sector with id 124"
         );
     }
 

--- a/sector-builder-ffi/examples/simple/main.rs
+++ b/sector-builder-ffi/examples/simple/main.rs
@@ -58,8 +58,8 @@ fn main() {
         .parse::<u64>()
         .expect("could not parse argument to a sector size");
 
-    unsafe { kill_restart_recovery(sector_size).unwrap() };
     unsafe { sector_builder_lifecycle(sector_size).unwrap() };
+    unsafe { kill_restart_recovery(sector_size).unwrap() };
 }
 
 /// A test which simulates a sector builder being shutdown impolitely (SIGKILL).

--- a/sector-builder-ffi/examples/simple/plumbing.rs
+++ b/sector-builder-ffi/examples/simple/plumbing.rs
@@ -79,7 +79,7 @@ pub(crate) unsafe fn get_sealed_sectors(
         panic!("{}", c_str_to_rust_str((*resp).error_msg))
     }
 
-    slice::from_raw_parts((*resp).sectors_ptr, (*resp).sectors_len).to_vec()
+    slice::from_raw_parts((*resp).meta_ptr, (*resp).meta_len).to_vec()
 }
 
 pub(crate) unsafe fn get_staged_sectors(

--- a/sector-builder-ffi/examples/simple/porcelain.rs
+++ b/sector-builder-ffi/examples/simple/porcelain.rs
@@ -60,6 +60,38 @@ pub(crate) unsafe fn get_sector_info(
         .collect()
 }
 
+pub(crate) unsafe fn seal_sector_nonblocking(
+    ptr: *mut sector_builder_ffi_SectorBuilder,
+    sector_id: u64,
+    seal_ticket: sector_builder_ffi_FFISealTicket,
+) {
+    let atomic_ptr = AtomicPtr::new(ptr);
+
+    thread::spawn(move || {
+        let sector_builder = atomic_ptr.into_inner();
+
+        let _ = seal_sector(
+            &mut Default::default(),
+            sector_builder,
+            sector_id,
+            seal_ticket,
+        );
+    });
+}
+
+pub(crate) unsafe fn resume_seal_sector_nonblocking(
+    ptr: *mut sector_builder_ffi_SectorBuilder,
+    sector_id: u64,
+) {
+    let atomic_ptr = AtomicPtr::new(ptr);
+
+    thread::spawn(move || {
+        let sector_builder = atomic_ptr.into_inner();
+
+        let _ = resume_seal_sector(&mut Default::default(), sector_builder, sector_id);
+    });
+}
+
 pub(crate) unsafe fn poll_for_sector_sealing_status(
     ptr: *mut sector_builder_ffi_SectorBuilder,
     sector_id: u64,

--- a/sector-builder-ffi/src/api.rs
+++ b/sector-builder-ffi/src/api.rs
@@ -185,6 +185,10 @@ pub unsafe extern "C" fn sector_builder_ffi_get_seal_status(
                     response.seal_status_code = FFISealStatus::Sealed;
                     response.sector_access = rust_str_to_c_str(meta.sector_access);
                     response.sector_id = u64::from(meta.sector_id);
+                    response.seal_ticket = FFISealTicket {
+                        block_height: meta.seal_ticket.block_height,
+                        ticket_bytes: meta.seal_ticket.ticket_bytes,
+                    };
 
                     mem::forget(meta.proof);
                     mem::forget(pieces);

--- a/sector-builder-ffi/src/api.rs
+++ b/sector-builder-ffi/src/api.rs
@@ -172,7 +172,10 @@ pub unsafe extern "C" fn sector_builder_ffi_get_seal_status(
                     mem::forget(meta.proof);
                     mem::forget(pieces);
                 }
-                SealStatus::Sealing => {
+                SealStatus::ReadyForSealing => {
+                    response.seal_status_code = FFISealStatus::Sealing;
+                }
+                SealStatus::Sealing(_) => {
                     response.seal_status_code = FFISealStatus::Sealing;
                 }
                 SealStatus::Pending => {
@@ -298,7 +301,10 @@ pub unsafe extern "C" fn sector_builder_ffi_get_staged_sectors(
                             sector.seal_status_code = FFISealStatus::Failed;
                             sector.seal_error_msg = rust_str_to_c_str(s.clone());
                         }
-                        SealStatus::Sealing => {
+                        SealStatus::ReadyForSealing => {
+                            sector.seal_status_code = FFISealStatus::Sealing;
+                        }
+                        SealStatus::Sealing(_) => {
                             sector.seal_status_code = FFISealStatus::Sealing;
                         }
                         SealStatus::Pending => {

--- a/sector-builder-ffi/src/api.rs
+++ b/sector-builder-ffi/src/api.rs
@@ -16,8 +16,11 @@ use crate::responses::{
 
 #[repr(C)]
 pub struct FFISealTicket {
-    height: u64,
-    bytes: [u8; 32],
+    /// the height at which we chose the ticket
+    pub height: u64,
+
+    /// bytes of the minimum ticket chosen from a block with given height
+    pub bytes: [u8; 32],
 }
 
 #[repr(C)]

--- a/sector-builder-ffi/src/api.rs
+++ b/sector-builder-ffi/src/api.rs
@@ -226,6 +226,10 @@ pub unsafe extern "C" fn sector_builder_ffi_get_sealed_sectors(
                     let snark_proof = meta.proof.clone();
 
                     let sector = responses::FFISealedSectorMetadata {
+                        seal_ticket: FFISealTicket {
+                            height: meta.seal_ticket.height,
+                            bytes: meta.seal_ticket.bytes,
+                        },
                         comm_d: meta.comm_d,
                         comm_r: meta.comm_r,
                         pieces_len: pieces.len(),

--- a/sector-builder-ffi/src/responses.rs
+++ b/sector-builder-ffi/src/responses.rs
@@ -8,7 +8,7 @@ use ffi_toolkit::free_c_str;
 use libc;
 use sector_builder::{SealedSectorHealth, SectorBuilderErr, SectorManagerErr};
 
-use crate::api::SectorBuilder;
+use crate::api::{FFISealTicket, SectorBuilder};
 
 #[repr(C)]
 #[derive(PartialEq, Debug)]
@@ -295,13 +295,14 @@ pub struct FFIStagedSectorMetadata {
 pub struct FFISealedSectorMetadata {
     pub comm_d: [u8; 32],
     pub comm_r: [u8; 32],
+    pub health: FFISealedSectorHealth,
     pub pieces_len: libc::size_t,
     pub pieces_ptr: *const FFIPieceMetadata,
     pub proofs_len: libc::size_t,
     pub proofs_ptr: *const u8,
+    pub seal_ticket: FFISealTicket,
     pub sector_access: *const libc::c_char,
     pub sector_id: u64,
-    pub health: FFISealedSectorHealth,
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/sector-builder-ffi/src/responses.rs
+++ b/sector-builder-ffi/src/responses.rs
@@ -260,7 +260,7 @@ pub struct GetSealStatusResponse {
     // sealed sector metadata
     pub comm_d: [u8; 32],
     pub comm_r: [u8; 32],
-    pub seal_ticket: [u8; 32],
+    pub seal_ticket: FFISealTicket,
     pub sector_access: *const libc::c_char,
     pub sector_id: u64,
     pub proof_len: libc::size_t,
@@ -320,7 +320,10 @@ impl Default for GetSealStatusResponse {
             seal_status_code: FFISealStatus::Failed,
             sector_access: ptr::null(),
             sector_id: 0,
-            seal_ticket: Default::default(),
+            seal_ticket: FFISealTicket {
+                block_height: 0,
+                ticket_bytes: Default::default(),
+            },
         }
     }
 }

--- a/sector-builder-ffi/src/responses.rs
+++ b/sector-builder-ffi/src/responses.rs
@@ -408,9 +408,8 @@ impl From<SealedSectorMetadata> for FFISealedSectorMetadata {
 pub struct GetSealedSectorsResponse {
     pub status_code: FCPResponseStatus,
     pub error_msg: *const libc::c_char,
-
-    pub sectors_len: libc::size_t,
-    pub sectors_ptr: *const FFISealedSectorMetadata,
+    pub meta_len: libc::size_t,
+    pub meta_ptr: *const FFISealedSectorMetadata,
 }
 
 impl Default for GetSealedSectorsResponse {
@@ -418,8 +417,8 @@ impl Default for GetSealedSectorsResponse {
         GetSealedSectorsResponse {
             status_code: FCPResponseStatus::FCPNoError,
             error_msg: ptr::null(),
-            sectors_len: 0,
-            sectors_ptr: ptr::null(),
+            meta_len: 0,
+            meta_ptr: ptr::null(),
         }
     }
 }

--- a/sector-builder-ffi/src/responses.rs
+++ b/sector-builder-ffi/src/responses.rs
@@ -125,6 +125,26 @@ impl Default for InitSectorBuilderResponse {
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// SetCurrentSealTicketResponse
+////////////////////////////////
+
+#[repr(C)]
+#[derive(DropStructMacro)]
+pub struct SetCurrentSealTicketResponse {
+    pub status_code: FCPResponseStatus,
+    pub error_msg: *const libc::c_char,
+}
+
+impl Default for SetCurrentSealTicketResponse {
+    fn default() -> SetCurrentSealTicketResponse {
+        SetCurrentSealTicketResponse {
+            status_code: FCPResponseStatus::FCPNoError,
+            error_msg: ptr::null(),
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// AddPieceResponse
 ////////////////////
 
@@ -208,7 +228,7 @@ pub struct GetSealStatusResponse {
     // sealed sector metadata
     pub comm_d: [u8; 32],
     pub comm_r: [u8; 32],
-    pub comm_r_star: [u8; 32],
+    pub seal_ticket: [u8; 32],
     pub sector_access: *const libc::c_char,
     pub sector_id: u64,
     pub proof_len: libc::size_t,
@@ -234,7 +254,6 @@ impl Default for GetSealStatusResponse {
             error_msg: ptr::null(),
             comm_d: Default::default(),
             comm_r: Default::default(),
-            comm_r_star: Default::default(),
             pieces_len: 0,
             pieces_ptr: ptr::null(),
             proof_len: 0,
@@ -243,6 +262,7 @@ impl Default for GetSealStatusResponse {
             seal_status_code: FFISealStatus::Failed,
             sector_access: ptr::null(),
             sector_id: 0,
+            seal_ticket: Default::default(),
         }
     }
 }
@@ -275,7 +295,6 @@ pub struct FFIStagedSectorMetadata {
 pub struct FFISealedSectorMetadata {
     pub comm_d: [u8; 32],
     pub comm_r: [u8; 32],
-    pub comm_r_star: [u8; 32],
     pub pieces_len: libc::size_t,
     pub pieces_ptr: *const FFIPieceMetadata,
     pub proofs_len: libc::size_t,

--- a/sector-builder/src/builder.rs
+++ b/sector-builder/src/builder.rs
@@ -86,7 +86,7 @@ impl<R: 'static + Send + std::io::Read> SectorBuilder<R> {
                     .expects(FATAL_NOLOAD)
                     .map(Into::into);
 
-            loaded.unwrap_or_else(|| SectorBuilderState::initialize(last_committed_sector_id))
+            loaded.unwrap_or_else(|| SectorBuilderState::new(last_committed_sector_id))
         };
 
         let max_user_bytes_per_staged_sector =

--- a/sector-builder/src/builder.rs
+++ b/sector-builder/src/builder.rs
@@ -18,10 +18,11 @@ use crate::scheduler::{PerformHealthCheck, Scheduler, SchedulerTask};
 use crate::state::SectorBuilderState;
 use crate::worker::*;
 use crate::SectorStore;
+use std::io::Read;
 
 const FATAL_NOLOAD: &str = "could not load snapshot";
 
-pub struct SectorBuilder<T> {
+pub struct SectorBuilder<T: Read + Send> {
     // Prevents FFI consumers from queueing behind long-running seal operations.
     worker_tx: mpsc::Sender<WorkerTask>,
 
@@ -212,7 +213,7 @@ impl<R: 'static + Send + std::io::Read> SectorBuilder<R> {
     }
 }
 
-impl<T> Drop for SectorBuilder<T> {
+impl<T: Read + Send> Drop for SectorBuilder<T> {
     fn drop(&mut self) {
         // Shut down main worker and sealers, too.
         let _ = self

--- a/sector-builder/src/builder.rs
+++ b/sector-builder/src/builder.rs
@@ -117,7 +117,7 @@ impl<R: 'static + Send + std::io::Read> SectorBuilder<R> {
         log_unrecov(self.run_blocking(|tx| SchedulerTask::ResumeSealSector(sector_id, tx)))
             .and_then(|x| {
                 x.first()
-                    .map(|y| y.clone())
+                    .cloned()
                     .ok_or_else(|| format_err!("resume_seal_sector expected one sector"))
             })
     }
@@ -131,7 +131,7 @@ impl<R: 'static + Send + std::io::Read> SectorBuilder<R> {
         log_unrecov(self.run_blocking(|tx| SchedulerTask::SealSector(sector_id, seal_ticket, tx)))
             .and_then(|x| {
                 x.first()
-                    .map(|y| y.clone())
+                    .cloned()
                     .ok_or_else(|| format_err!("seal_sector expected one sector"))
             })
     }

--- a/sector-builder/src/builder.rs
+++ b/sector-builder/src/builder.rs
@@ -23,7 +23,7 @@ const FATAL_NOLOAD: &str = "could not load snapshot";
 
 pub struct SectorBuilder<T> {
     // Prevents FFI consumers from queueing behind long-running seal operations.
-    worker_tx: mpsc::Sender<WorkerTask<T>>,
+    worker_tx: mpsc::Sender<WorkerTask>,
 
     // For additional seal concurrency, add more workers here.
     workers: Vec<Worker>,

--- a/sector-builder/src/helpers/get_seal_status.rs
+++ b/sector-builder/src/helpers/get_seal_status.rs
@@ -61,8 +61,9 @@ mod tests {
         );
 
         SectorBuilderState {
+            current_seal_ticket: Default::default(),
+            last_committed_sector_id: 4.into(),
             staged: StagedState {
-                sector_id_nonce: 0,
                 sectors: staged_sectors,
             },
             sealed: SealedState {

--- a/sector-builder/src/helpers/get_seal_status.rs
+++ b/sector-builder/src/helpers/get_seal_status.rs
@@ -40,8 +40,8 @@ mod tests {
             StagedSectorMetadata {
                 sector_id: SectorId::from(2),
                 seal_status: SealStatus::Sealing(SealTicket {
-                    height: 1,
-                    bytes: [0u8; 32],
+                    block_height: 1,
+                    ticket_bytes: [0u8; 32],
                 }),
                 ..Default::default()
             },
@@ -65,7 +65,6 @@ mod tests {
         );
 
         SectorBuilderState {
-            current_seal_ticket: Default::default(),
             last_committed_sector_id: 4.into(),
             staged: StagedState {
                 sectors: staged_sectors,

--- a/sector-builder/src/helpers/get_seal_status.rs
+++ b/sector-builder/src/helpers/get_seal_status.rs
@@ -29,6 +29,7 @@ mod tests {
     use crate::state::{SealedState, SectorBuilderState, StagedState};
 
     use super::*;
+    use crate::SealTicket;
 
     fn setup() -> SectorBuilderState {
         let mut staged_sectors: HashMap<SectorId, StagedSectorMetadata> = Default::default();
@@ -38,7 +39,10 @@ mod tests {
             SectorId::from(2),
             StagedSectorMetadata {
                 sector_id: SectorId::from(2),
-                seal_status: SealStatus::Sealing,
+                seal_status: SealStatus::Sealing(SealTicket {
+                    height: 1,
+                    bytes: [0u8; 32],
+                }),
                 ..Default::default()
             },
         );
@@ -84,7 +88,7 @@ mod tests {
 
         let result = get_seal_status(&staged_state, &sealed_state, SectorId::from(2)).unwrap();
         match result {
-            SealStatus::Sealing => (),
+            SealStatus::Sealing(_) => (),
             _ => panic!("should have been SealStatus::Sealing"),
         }
 

--- a/sector-builder/src/helpers/get_sectors_ready_for_sealing.rs
+++ b/sector-builder/src/helpers/get_sectors_ready_for_sealing.rs
@@ -86,10 +86,7 @@ mod tests {
         make_meta(&mut m, SectorId::from(200), 0, true);
         make_meta(&mut m, SectorId::from(201), 0, true);
 
-        let state = StagedState {
-            sector_id_nonce: 100,
-            sectors: m,
-        };
+        let state = StagedState { sectors: m };
 
         let to_seal: Vec<SectorId> =
             get_sectors_ready_for_sealing(&state, UnpaddedBytesAmount(127), 10, true)
@@ -106,10 +103,7 @@ mod tests {
         make_meta(&mut m, SectorId::from(200), 127, true);
         make_meta(&mut m, SectorId::from(201), 0, true);
 
-        let state = StagedState {
-            sector_id_nonce: 100,
-            sectors: m,
-        };
+        let state = StagedState { sectors: m };
 
         let to_seal: Vec<SectorId> =
             get_sectors_ready_for_sealing(&state, UnpaddedBytesAmount(127), 10, false)
@@ -128,10 +122,7 @@ mod tests {
         make_meta(&mut m, SectorId::from(202), 0, true);
         make_meta(&mut m, SectorId::from(203), 0, true);
 
-        let state = StagedState {
-            sector_id_nonce: 100,
-            sectors: m,
-        };
+        let state = StagedState { sectors: m };
 
         let to_seal: Vec<SectorId> =
             get_sectors_ready_for_sealing(&state, UnpaddedBytesAmount(127), 2, false)
@@ -150,10 +141,7 @@ mod tests {
         make_meta(&mut m, SectorId::from(202), 0, true);
         make_meta(&mut m, SectorId::from(203), 0, true);
 
-        let state = StagedState {
-            sector_id_nonce: 100,
-            sectors: m,
-        };
+        let state = StagedState { sectors: m };
 
         let to_seal: Vec<SectorId> =
             get_sectors_ready_for_sealing(&state, UnpaddedBytesAmount(127), 4, false)
@@ -172,10 +160,7 @@ mod tests {
         make_meta(&mut m, SectorId::from(202), 127, false);
         make_meta(&mut m, SectorId::from(203), 127, false);
 
-        let state = StagedState {
-            sector_id_nonce: 100,
-            sectors: m,
-        };
+        let state = StagedState { sectors: m };
 
         let to_seal: Vec<SectorId> =
             get_sectors_ready_for_sealing(&state, UnpaddedBytesAmount(127), 4, false)

--- a/sector-builder/src/helpers/get_sectors_ready_for_sealing.rs
+++ b/sector-builder/src/helpers/get_sectors_ready_for_sealing.rs
@@ -58,8 +58,8 @@ mod tests {
             SealStatus::Pending
         } else {
             SealStatus::Sealing(SealTicket {
-                height: 1,
-                bytes: [0u8; 32],
+                block_height: 1,
+                ticket_bytes: [0u8; 32],
             })
         };
 

--- a/sector-builder/src/helpers/get_sectors_ready_for_sealing.rs
+++ b/sector-builder/src/helpers/get_sectors_ready_for_sealing.rs
@@ -45,6 +45,7 @@ mod tests {
 
     use crate::metadata::{PieceMetadata, StagedSectorMetadata};
     use crate::state::StagedState;
+    use crate::SealTicket;
     use storage_proofs::sector::SectorId;
 
     fn make_meta(
@@ -56,7 +57,10 @@ mod tests {
         let seal_status = if accepting_data {
             SealStatus::Pending
         } else {
-            SealStatus::Sealing
+            SealStatus::Sealing(SealTicket {
+                height: 1,
+                bytes: [0u8; 32],
+            })
         };
 
         m.insert(

--- a/sector-builder/src/helpers/snapshots.rs
+++ b/sector-builder/src/helpers/snapshots.rs
@@ -6,12 +6,12 @@ use crate::kv_store::KeyValueStore;
 use crate::state::*;
 
 pub struct SnapshotKey {
-    prover_id: [u8; 31],
+    prover_id: [u8; 32],
     sector_size: PaddedBytesAmount,
 }
 
 impl SnapshotKey {
-    pub fn new(prover_id: [u8; 31], sector_size: PaddedBytesAmount) -> SnapshotKey {
+    pub fn new(prover_id: [u8; 32], sector_size: PaddedBytesAmount) -> SnapshotKey {
         SnapshotKey {
             prover_id,
             sector_size,
@@ -82,14 +82,13 @@ mod tests {
 
             m.insert(SectorId::from(123), Default::default());
 
-            let staged_state = StagedState {
-                sector_id_nonce: 100,
-                sectors: m,
-            };
+            let staged_state = StagedState { sectors: m };
 
             let sealed_state = Default::default();
 
             SectorBuilderState {
+                current_seal_ticket: Default::default(),
+                last_committed_sector_id: 100.into(),
                 staged: staged_state,
                 sealed: sealed_state,
             }
@@ -101,22 +100,21 @@ mod tests {
 
             m.insert(SectorId::from(666), Default::default());
 
-            let staged_state = StagedState {
-                sector_id_nonce: 102,
-                sectors: m,
-            };
+            let staged_state = StagedState { sectors: m };
 
             let sealed_state = Default::default();
 
             SectorBuilderState {
+                current_seal_ticket: Default::default(),
+                last_committed_sector_id: 102.into(),
                 staged: staged_state,
                 sealed: sealed_state,
             }
         };
 
-        let key_a = SnapshotKey::new([0; 31], PaddedBytesAmount(1024));
-        let key_b = SnapshotKey::new([0; 31], PaddedBytesAmount(1111));
-        let key_c = SnapshotKey::new([1; 31], PaddedBytesAmount(1024));
+        let key_a = SnapshotKey::new([0; 32], PaddedBytesAmount(1024));
+        let key_b = SnapshotKey::new([0; 32], PaddedBytesAmount(1111));
+        let key_c = SnapshotKey::new([1; 32], PaddedBytesAmount(1024));
 
         // persist both snapshots
         let _ = persist_snapshot(&kv_store, &key_a, &snapshot_a).unwrap();

--- a/sector-builder/src/helpers/snapshots.rs
+++ b/sector-builder/src/helpers/snapshots.rs
@@ -87,7 +87,6 @@ mod tests {
             let sealed_state = Default::default();
 
             SectorBuilderState {
-                current_seal_ticket: Default::default(),
                 last_committed_sector_id: 100.into(),
                 staged: staged_state,
                 sealed: sealed_state,
@@ -105,7 +104,6 @@ mod tests {
             let sealed_state = Default::default();
 
             SectorBuilderState {
-                current_seal_ticket: Default::default(),
                 last_committed_sector_id: 102.into(),
                 staged: staged_state,
                 sealed: sealed_state,

--- a/sector-builder/src/metadata.rs
+++ b/sector-builder/src/metadata.rs
@@ -35,7 +35,7 @@ pub struct PieceMetadata {
     pub piece_inclusion_proof: Option<Vec<u8>>,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub enum SealStatus {
     Failed(String),
     Pending,
@@ -44,15 +44,24 @@ pub enum SealStatus {
     Sealing(SealTicket),
 }
 
-impl PartialEq for SealStatus {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (SealStatus::Failed(_), SealStatus::Failed(_)) => true,
-            (SealStatus::Pending, SealStatus::Pending) => true,
-            (SealStatus::Sealed(_), SealStatus::Sealed(_)) => true,
-            (SealStatus::ReadyForSealing, SealStatus::ReadyForSealing) => true,
-            (SealStatus::Sealing(_), SealStatus::Sealing(_)) => true,
-            (_, _) => false,
+impl SealStatus {
+    pub fn is_sealing(&self) -> bool {
+        match self {
+            SealStatus::Failed(_) => false,
+            SealStatus::Pending => false,
+            SealStatus::Sealed(_) => false,
+            SealStatus::ReadyForSealing => false,
+            SealStatus::Sealing(_) => true,
+        }
+    }
+
+    pub fn is_ready_for_sealing(&self) -> bool {
+        match self {
+            SealStatus::Failed(_) => false,
+            SealStatus::Pending => false,
+            SealStatus::Sealed(_) => false,
+            SealStatus::ReadyForSealing => true,
+            SealStatus::Sealing(_) => false,
         }
     }
 }

--- a/sector-builder/src/metadata.rs
+++ b/sector-builder/src/metadata.rs
@@ -1,4 +1,5 @@
 use filecoin_proofs::types::UnpaddedBytesAmount;
+use filecoin_proofs::PersistentAux;
 use serde::{Deserialize, Serialize};
 use storage_proofs::sector::SectorId;
 
@@ -15,7 +16,6 @@ pub struct SealedSectorMetadata {
     pub sector_id: SectorId,
     pub sector_access: String,
     pub pieces: Vec<PieceMetadata>,
-    pub comm_r_star: [u8; 32],
     pub comm_r: [u8; 32],
     pub comm_d: [u8; 32],
     pub proof: Vec<u8>,
@@ -23,6 +23,8 @@ pub struct SealedSectorMetadata {
     pub blake2b_checksum: Vec<u8>,
     /// number of bytes in the sealed sector-file as returned by `std::fs::metadata`
     pub len: u64,
+    pub p_aux: PersistentAux,
+    pub seal_ticket: SealTicket,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
@@ -39,6 +41,12 @@ pub enum SealStatus {
     Pending,
     Sealed(Box<SealedSectorMetadata>),
     Sealing,
+}
+
+#[derive(Clone, Serialize, Default, Deserialize, Debug, PartialEq)]
+pub struct SealTicket {
+    pub height: u64,
+    pub bytes: [u8; 32],
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/sector-builder/src/metadata.rs
+++ b/sector-builder/src/metadata.rs
@@ -59,7 +59,10 @@ impl PartialEq for SealStatus {
 
 #[derive(Clone, Serialize, Default, Deserialize, Debug, PartialEq)]
 pub struct SealTicket {
+    /// the height at which we chose the ticket
     pub height: u64,
+
+    /// bytes of the minimum ticket chosen from a block with given height
     pub bytes: [u8; 32],
 }
 

--- a/sector-builder/src/metadata.rs
+++ b/sector-builder/src/metadata.rs
@@ -35,12 +35,26 @@ pub struct PieceMetadata {
     pub piece_inclusion_proof: Option<Vec<u8>>,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub enum SealStatus {
     Failed(String),
     Pending,
     Sealed(Box<SealedSectorMetadata>),
-    Sealing,
+    ReadyForSealing,
+    Sealing(SealTicket),
+}
+
+impl PartialEq for SealStatus {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (SealStatus::Failed(_), SealStatus::Failed(_)) => true,
+            (SealStatus::Pending, SealStatus::Pending) => true,
+            (SealStatus::Sealed(_), SealStatus::Sealed(_)) => true,
+            (SealStatus::ReadyForSealing, SealStatus::ReadyForSealing) => true,
+            (SealStatus::Sealing(_), SealStatus::Sealing(_)) => true,
+            (_, _) => false,
+        }
+    }
 }
 
 #[derive(Clone, Serialize, Default, Deserialize, Debug, PartialEq)]

--- a/sector-builder/src/metadata.rs
+++ b/sector-builder/src/metadata.rs
@@ -41,27 +41,29 @@ pub enum SealStatus {
     Pending,
     Sealed(Box<SealedSectorMetadata>),
     ReadyForSealing,
+    Paused(SealTicket),
     Sealing(SealTicket),
 }
 
 impl SealStatus {
     pub fn is_sealing(&self) -> bool {
         match self {
-            SealStatus::Failed(_) => false,
-            SealStatus::Pending => false,
-            SealStatus::Sealed(_) => false,
-            SealStatus::ReadyForSealing => false,
             SealStatus::Sealing(_) => true,
+            _ => false,
         }
     }
 
     pub fn is_ready_for_sealing(&self) -> bool {
         match self {
-            SealStatus::Failed(_) => false,
-            SealStatus::Pending => false,
-            SealStatus::Sealed(_) => false,
             SealStatus::ReadyForSealing => true,
-            SealStatus::Sealing(_) => false,
+            _ => false,
+        }
+    }
+
+    pub fn is_paused(&self) -> bool {
+        match self {
+            SealStatus::Paused(_) => true,
+            _ => false,
         }
     }
 }
@@ -69,10 +71,10 @@ impl SealStatus {
 #[derive(Clone, Serialize, Default, Deserialize, Debug, PartialEq)]
 pub struct SealTicket {
     /// the height at which we chose the ticket
-    pub height: u64,
+    pub block_height: u64,
 
     /// bytes of the minimum ticket chosen from a block with given height
-    pub bytes: [u8; 32],
+    pub ticket_bytes: [u8; 32],
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/sector-builder/src/metadata_manager.rs
+++ b/sector-builder/src/metadata_manager.rs
@@ -69,7 +69,7 @@ impl<T: KeyValueStore, S: SectorStore> SectorMetadataManager<T, S> {
         }
 
         GeneratePoStTaskPrototype {
-            challenge_seed: challenge_seed.clone(),
+            challenge_seed: *challenge_seed,
             private_replicas: replicas,
             post_config: self.sector_store.proofs_config().post_config(),
         }
@@ -211,9 +211,9 @@ impl<T: KeyValueStore, S: SectorStore> SectorMetadataManager<T, S> {
     }
 
     // Commits a sector to a given ticket and flips its status to Sealing.
-    pub fn commit_sector_to_ticket(&mut self, sector_id: &SectorId, seal_ticket: &SealTicket) {
+    pub fn commit_sector_to_ticket(&mut self, sector_id: SectorId, seal_ticket: &SealTicket) {
         for (k, mut v) in &mut self.state.staged.sectors {
-            if sector_id == k {
+            if sector_id == *k {
                 v.seal_status = SealStatus::Sealing(seal_ticket.clone());
                 self.checkpoint().expects(FATAL_SNPSHT);
 
@@ -401,7 +401,7 @@ impl<T: KeyValueStore, S: SectorStore> SectorMetadataManager<T, S> {
         .into_iter()
         .collect();
 
-        for (_, mut v) in &mut staged_state.sectors {
+        for mut v in &mut staged_state.sectors.values_mut() {
             if to_be_sealed.contains(&v.sector_id) {
                 v.seal_status = SealStatus::ReadyForSealing;
             }

--- a/sector-builder/src/metadata_manager.rs
+++ b/sector-builder/src/metadata_manager.rs
@@ -258,15 +258,6 @@ impl<T: KeyValueStore, S: SectorStore> SectorMetadataManager<T, S> {
         }
     }
 
-    // Creates a SealTaskPrototype suitable for resuming a previously-paused
-    // seal.
-    pub fn create_resume_seal_task_protos<P: FnMut(&StagedSectorMetadata) -> bool>(
-        &mut self,
-        predicate: P,
-    ) -> Result<Vec<SealTaskPrototype>> {
-        self.create_seal_task_protos(Default::default(), predicate)
-    }
-
     // Create a SealTaskPrototype for each staged sector matching the predicate.
     // If a ticket is already associated with the staged sector, use it to
     // create the proto. Otherwise use the provided ticket.

--- a/sector-builder/src/metadata_manager.rs
+++ b/sector-builder/src/metadata_manager.rs
@@ -19,6 +19,7 @@ use crate::{
 };
 use crate::{helpers, SealTicket};
 use helpers::SnapshotKey;
+use std::io::Read;
 
 const FATAL_SNPSHT: &str = "could not snapshot";
 
@@ -172,11 +173,11 @@ impl<T: KeyValueStore, S: SectorStore> SectorMetadataManager<T, S> {
 
     // Write the piece to storage, obtaining the sector id with which the
     // piece-bytes are now associated and a vector of SealTaskPrototypes.
-    pub fn add_piece(
+    pub fn add_piece<U: Read>(
         &mut self,
         piece_key: String,
         piece_bytes_amount: u64,
-        piece_file: impl std::io::Read,
+        piece_file: U,
         store_until: SecondsSinceEpoch,
     ) -> Result<SectorId> {
         let destination_sector_id = helpers::add_piece(

--- a/sector-builder/src/scheduler.rs
+++ b/sector-builder/src/scheduler.rs
@@ -150,10 +150,7 @@ impl Scheduler {
                         match r_protos {
                             Ok(protos) => {
                                 for p in &protos {
-                                    m.commit_sector_to_ticket(
-                                        p.sector_id.clone(),
-                                        p.seal_ticket.clone(),
-                                    );
+                                    m.commit_sector_to_ticket(p.sector_id, p.seal_ticket.clone());
                                 }
 
                                 worker_tx
@@ -177,10 +174,7 @@ impl Scheduler {
                         match r_protos {
                             Ok(protos) => {
                                 for p in &protos {
-                                    m.commit_sector_to_ticket(
-                                        p.sector_id.clone(),
-                                        p.seal_ticket.clone(),
-                                    );
+                                    m.commit_sector_to_ticket(p.sector_id, p.seal_ticket.clone());
                                 }
 
                                 worker_tx
@@ -206,10 +200,7 @@ impl Scheduler {
                         match r_protos {
                             Ok(protos) => {
                                 for p in &protos {
-                                    m.commit_sector_to_ticket(
-                                        p.sector_id.clone(),
-                                        p.seal_ticket.clone(),
-                                    );
+                                    m.commit_sector_to_ticket(p.sector_id, p.seal_ticket.clone());
                                 }
 
                                 worker_tx

--- a/sector-builder/src/scheduler.rs
+++ b/sector-builder/src/scheduler.rs
@@ -172,7 +172,7 @@ impl<T: KeyValueStore, U: SectorStore, V: 'static + Send + std::io::Read> TaskHa
                         ));
                     }
 
-                    return None;
+                    None
                 };
 
                 self.seal_matching(tx, Default::default(), p, f);
@@ -190,7 +190,7 @@ impl<T: KeyValueStore, U: SectorStore, V: 'static + Send + std::io::Read> TaskHa
                         ));
                     }
 
-                    return None;
+                    None
                 };
 
                 self.seal_matching(tx, seal_ticket, p, f);

--- a/sector-builder/src/scheduler.rs
+++ b/sector-builder/src/scheduler.rs
@@ -148,7 +148,7 @@ impl Scheduler {
                         }) {
                             Ok(protos) => {
                                 for p in protos {
-                                    m.commit_sector_to_ticket(&p.sector_id, &p.seal_ticket);
+                                    m.commit_sector_to_ticket(p.sector_id, &p.seal_ticket);
 
                                     worker_tx
                                         .send(WorkerTask::from_seal_proto(
@@ -173,7 +173,7 @@ impl Scheduler {
                         }) {
                             Ok(protos) => {
                                 for p in protos {
-                                    m.commit_sector_to_ticket(&p.sector_id, &p.seal_ticket);
+                                    m.commit_sector_to_ticket(p.sector_id, &p.seal_ticket);
 
                                     worker_tx
                                         .send(WorkerTask::from_seal_proto(

--- a/sector-builder/src/scheduler.rs
+++ b/sector-builder/src/scheduler.rs
@@ -85,7 +85,10 @@ pub enum SchedulerTask<T: Read + Send> {
 
 impl<T: Read + Send> SchedulerTask<T> {
     fn should_continue(&self) -> bool {
-        true
+        match self {
+            SchedulerTask::Shutdown => false,
+            _ => true,
+        }
     }
 }
 

--- a/sector-builder/src/scheduler.rs
+++ b/sector-builder/src/scheduler.rs
@@ -83,9 +83,7 @@ impl Scheduler {
         // we should immediately restart sealing.
         //
         // For more information, see rust-fil-sector-builder/17.
-        let protos = m.create_seal_task_protos(|x| {
-            x.seal_status == SealStatus::Sealing(Default::default())
-        })?;
+        let protos = m.create_seal_task_protos(|x| x.seal_status.is_sealing())?;
 
         for p in protos {
             worker_tx
@@ -143,9 +141,7 @@ impl Scheduler {
                     SchedulerTask::SealAllStagedSectors(tx) => {
                         m.mark_all_sectors_for_sealing();
 
-                        match m.create_seal_task_protos(|x| {
-                            x.seal_status == SealStatus::ReadyForSealing
-                        }) {
+                        match m.create_seal_task_protos(|x| x.seal_status.is_ready_for_sealing()) {
                             Ok(protos) => {
                                 for p in protos {
                                     m.commit_sector_to_ticket(p.sector_id, &p.seal_ticket);
@@ -168,9 +164,7 @@ impl Scheduler {
                     SchedulerTask::SetCurrentSealTicket(seal_ticket, tx) => {
                         m.set_current_seal_ticket(seal_ticket);
 
-                        match m.create_seal_task_protos(|x| {
-                            x.seal_status == SealStatus::ReadyForSealing
-                        }) {
+                        match m.create_seal_task_protos(|x| x.seal_status.is_ready_for_sealing()) {
                             Ok(protos) => {
                                 for p in protos {
                                     m.commit_sector_to_ticket(p.sector_id, &p.seal_ticket);

--- a/sector-builder/src/scheduler.rs
+++ b/sector-builder/src/scheduler.rs
@@ -210,7 +210,10 @@ impl Scheduler {
                             .expects(FATAL_NOSEND);
                     }
                     SchedulerTask::GeneratePoSt(comm_rs, chg_seed, faults, tx) => {
-                        tx.send(m.generate_post(&comm_rs, &chg_seed, faults))
+                        let proto = m.create_generate_post_task_proto(&comm_rs, &chg_seed, faults);
+
+                        worker_tx
+                            .send(WorkerTask::from_generate_post_proto(proto, tx.clone()))
                             .expects(FATAL_NOSEND);
                     }
                     SchedulerTask::Shutdown => break,

--- a/sector-builder/src/state.rs
+++ b/sector-builder/src/state.rs
@@ -23,7 +23,7 @@ pub struct SectorBuilderState {
 }
 
 impl SectorBuilderState {
-    pub fn initialize(last_committed_sector_id: SectorId) -> SectorBuilderState {
+    pub fn new(last_committed_sector_id: SectorId) -> SectorBuilderState {
         SectorBuilderState {
             last_committed_sector_id,
             staged: StagedState {

--- a/sector-builder/src/state.rs
+++ b/sector-builder/src/state.rs
@@ -4,7 +4,6 @@ use serde::{Deserialize, Serialize};
 use storage_proofs::sector::SectorId;
 
 use crate::metadata::{SealedSectorMetadata, StagedSectorMetadata};
-use crate::SealTicket;
 
 #[derive(Default, Serialize, Deserialize, Debug, PartialEq)]
 pub struct StagedState {
@@ -18,19 +17,14 @@ pub struct SealedState {
 
 #[derive(Default, Serialize, Deserialize, Debug, PartialEq)]
 pub struct SectorBuilderState {
-    pub current_seal_ticket: SealTicket,
     pub last_committed_sector_id: SectorId,
     pub staged: StagedState,
     pub sealed: SealedState,
 }
 
 impl SectorBuilderState {
-    pub fn new(
-        current_seal_ticket: SealTicket,
-        last_committed_sector_id: SectorId,
-    ) -> SectorBuilderState {
+    pub fn initialize(last_committed_sector_id: SectorId) -> SectorBuilderState {
         SectorBuilderState {
-            current_seal_ticket,
             last_committed_sector_id,
             staged: StagedState {
                 sectors: Default::default(),

--- a/sector-builder/src/state.rs
+++ b/sector-builder/src/state.rs
@@ -4,10 +4,10 @@ use serde::{Deserialize, Serialize};
 use storage_proofs::sector::SectorId;
 
 use crate::metadata::{SealedSectorMetadata, StagedSectorMetadata};
+use crate::SealTicket;
 
 #[derive(Default, Serialize, Deserialize, Debug, PartialEq)]
 pub struct StagedState {
-    pub sector_id_nonce: u64,
     pub sectors: HashMap<SectorId, StagedSectorMetadata>,
 }
 
@@ -18,15 +18,21 @@ pub struct SealedState {
 
 #[derive(Default, Serialize, Deserialize, Debug, PartialEq)]
 pub struct SectorBuilderState {
+    pub current_seal_ticket: SealTicket,
+    pub last_committed_sector_id: SectorId,
     pub staged: StagedState,
     pub sealed: SealedState,
 }
 
 impl SectorBuilderState {
-    pub fn new(last_committed_sector_id: SectorId) -> SectorBuilderState {
+    pub fn new(
+        current_seal_ticket: SealTicket,
+        last_committed_sector_id: SectorId,
+    ) -> SectorBuilderState {
         SectorBuilderState {
+            current_seal_ticket,
+            last_committed_sector_id,
             staged: StagedState {
-                sector_id_nonce: u64::from(last_committed_sector_id),
                 sectors: Default::default(),
             },
             sealed: Default::default(),

--- a/sector-builder/src/worker.rs
+++ b/sector-builder/src/worker.rs
@@ -88,9 +88,9 @@ impl<T> WorkerTask<T> {
     ) -> WorkerTask<T> {
         WorkerTask::GeneratePoSt {
             challenge_seed: proto.challenge_seed,
-            private_replicas: proto.private_replicas,
-            post_config: proto.post_config,
             done_tx,
+            post_config: proto.post_config,
+            private_replicas: proto.private_replicas,
         }
     }
 
@@ -98,25 +98,15 @@ impl<T> WorkerTask<T> {
         proto: SealTaskPrototype,
         done_tx: mpsc::SyncSender<SchedulerTask<T>>,
     ) -> WorkerTask<T> {
-        let SealTaskPrototype {
-            piece_lens,
-            porep_config,
-            seal_ticket,
-            sealed_sector_access,
-            sealed_sector_path,
-            sector_id,
-            staged_sector_path,
-        } = proto;
-
         WorkerTask::Seal {
-            piece_lens,
-            porep_config,
-            seal_ticket,
-            sealed_sector_access,
-            sealed_sector_path,
-            sector_id,
-            staged_sector_path,
             done_tx,
+            piece_lens: proto.piece_lens,
+            porep_config: proto.porep_config,
+            seal_ticket: proto.seal_ticket,
+            sealed_sector_access: proto.sealed_sector_access,
+            sealed_sector_path: proto.sealed_sector_path,
+            sector_id: proto.sector_id,
+            staged_sector_path: proto.staged_sector_path,
         }
     }
 
@@ -125,28 +115,17 @@ impl<T> WorkerTask<T> {
         caller_done_tx: mpsc::SyncSender<Result<Vec<u8>>>,
         done_tx: mpsc::SyncSender<SchedulerTask<T>>,
     ) -> WorkerTask<T> {
-        let UnsealTaskPrototype {
-            comm_d,
-            destination_path,
-            piece_len,
-            piece_start_byte,
-            porep_config,
-            seal_ticket,
-            sector_id,
-            source_path,
-        } = proto;
-
         WorkerTask::Unseal {
             caller_done_tx,
-            comm_d,
-            destination_path,
-            piece_len,
-            piece_start_byte,
-            porep_config,
-            seal_ticket,
-            sector_id,
-            source_path,
+            comm_d: proto.comm_d,
+            destination_path: proto.destination_path,
             done_tx,
+            piece_len: proto.piece_len,
+            piece_start_byte: proto.piece_start_byte,
+            porep_config: proto.porep_config,
+            seal_ticket: proto.seal_ticket,
+            sector_id: proto.sector_id,
+            source_path: proto.source_path,
         }
     }
 }

--- a/sector-builder/src/worker.rs
+++ b/sector-builder/src/worker.rs
@@ -29,6 +29,7 @@ pub struct UnsealTaskPrototype {
     pub(crate) source_path: PathBuf,
 }
 
+#[derive(Debug, Clone)]
 pub struct SealTaskPrototype {
     pub(crate) piece_lens: Vec<UnpaddedBytesAmount>,
     pub(crate) porep_config: PoRepConfig,


### PR DESCRIPTION
## Why does this PR exist?

The upstream rust-fil-proofs API was recently updated to accommodate stacked DRG+ / column commitments.

## What's in this PR?

- offload PoSt generation to worker thread, unblocking main loop
- PersistentAux saved to metadata store and used when generating PoSt
- caller to schedule seal calls
- caller to schedule resumption if builder terminated in middle of sealing