### PR TITLE
Feat/sector importing api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,15 +799,17 @@ dependencies = [
 [[package]]
 name = "filecoin-proofs-ffi"
 version = "0.7.3"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs-ffi.git#17c6a09a5746959a39925e91eed2d096bc49778c"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs-ffi.git?branch=feat/sector-importing-api#99cc445a7e859644631f6a87ac0785f533e32ab1"
 dependencies = [
  "cbindgen 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "drop_struct_macro_derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi-toolkit 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "filecoin-proofs 0.6.4 (git+https://github.com/filecoin-project/rust-fil-proofs.git)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-proofs 0.6.2 (git+https://github.com/filecoin-project/rust-fil-proofs.git)",
@@ -2051,7 +2053,7 @@ dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi-toolkit 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "filecoin-proofs 0.6.4 (git+https://github.com/filecoin-project/rust-fil-proofs.git)",
- "filecoin-proofs-ffi 0.7.3 (git+https://github.com/filecoin-project/rust-fil-proofs-ffi.git)",
+ "filecoin-proofs-ffi 0.7.3 (git+https://github.com/filecoin-project/rust-fil-proofs-ffi.git?branch=feat/sector-importing-api)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2835,7 +2837,7 @@ dependencies = [
 "checksum fil-ocl-core 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ecd0aa5895d05824d7eaa38b999c91e9071acb74b304488220e8f8bb555d1ad1"
 "checksum fil-sapling-crypto 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "289474ceb38d2dc0c9ba0e97220064d18848d3984543d8e858e191f4886571f6"
 "checksum filecoin-proofs 0.6.4 (git+https://github.com/filecoin-project/rust-fil-proofs.git)" = "<none>"
-"checksum filecoin-proofs-ffi 0.7.3 (git+https://github.com/filecoin-project/rust-fil-proofs-ffi.git)" = "<none>"
+"checksum filecoin-proofs-ffi 0.7.3 (git+https://github.com/filecoin-project/rust-fil-proofs-ffi.git?branch=feat/sector-importing-api)" = "<none>"
 "checksum filetime 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6bd7380b54ced79dda72ecc35cc4fbbd1da6bba54afaa37e96fd1c2a308cd469"
 "checksum flate2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ad3c5233c9a940c8719031b423d7e6c16af66e031cb0420b0896f5245bf181d3"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,7 @@ name = "backtrace-sys"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -136,7 +136,7 @@ version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cexpr 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cexpr 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "clang-sys 0.28.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -300,12 +300,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cexpr"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -672,7 +672,7 @@ dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "synstructure 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -799,17 +799,15 @@ dependencies = [
 [[package]]
 name = "filecoin-proofs-ffi"
 version = "0.7.3"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs-ffi.git?branch=feat/sector-importing-api#99cc445a7e859644631f6a87ac0785f533e32ab1"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs-ffi.git#a5e481893bcd1ba6afedeae9cabe0a2ffb3efe95"
 dependencies = [
  "cbindgen 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "drop_struct_macro_derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi-toolkit 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "filecoin-proofs 0.6.4 (git+https://github.com/filecoin-project/rust-fil-proofs.git)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-proofs 0.6.2 (git+https://github.com/filecoin-project/rust-fil-proofs.git)",
@@ -1113,7 +1111,7 @@ name = "libloading"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1150,6 +1148,11 @@ dependencies = [
 [[package]]
 name = "matches"
 version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "maybe-uninit"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1452,7 +1455,7 @@ name = "openssl-src"
 version = "111.6.0+1.1.1d"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1461,7 +1464,7 @@ version = "0.9.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-src 111.6.0+1.1.1d (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1525,7 +1528,7 @@ dependencies = [
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2053,7 +2056,7 @@ dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi-toolkit 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "filecoin-proofs 0.6.4 (git+https://github.com/filecoin-project/rust-fil-proofs.git)",
- "filecoin-proofs-ffi 0.7.3 (git+https://github.com/filecoin-project/rust-fil-proofs-ffi.git?branch=feat/sector-importing-api)",
+ "filecoin-proofs-ffi 0.7.3 (git+https://github.com/filecoin-project/rust-fil-proofs-ffi.git)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2202,8 +2205,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "smallvec"
-version = "0.6.12"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "storage-proofs"
@@ -2294,7 +2300,7 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2564,7 +2570,7 @@ name = "unicode-normalization"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "smallvec 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2789,8 +2795,8 @@ dependencies = [
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
 "checksum cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "926013f2860c46252efceabb19f4a6b308197505082c609025aa6706c011d427"
 "checksum cbindgen 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9daec6140ab4dcd38c3dd57e580b59a621172a526ac79f1527af760a55afeafd"
-"checksum cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)" = "0213d356d3c4ea2c18c40b037c3be23cd639825c18f25ee670ac7813beeef99c"
-"checksum cexpr 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7fa24eb00d5ffab90eaeaf1092ac85c04c64aaf358ea6f84505b8116d24c6af"
+"checksum cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)" = "aa87058dce70a3ff5621797f1506cb837edd02ac4c0ae642b4542dce802908b8"
+"checksum cexpr 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fce5b5fb86b0c57c20c834c1b412fd09c77c8a59b9473f86272709e78874cd1d"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum cgmath 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)" = "64a4b57c8f4e3a2e9ac07e0f6abc9c24b6fc9e1b54c3478cfb598f3d0023e51c"
 "checksum chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
@@ -2837,7 +2843,7 @@ dependencies = [
 "checksum fil-ocl-core 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ecd0aa5895d05824d7eaa38b999c91e9071acb74b304488220e8f8bb555d1ad1"
 "checksum fil-sapling-crypto 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "289474ceb38d2dc0c9ba0e97220064d18848d3984543d8e858e191f4886571f6"
 "checksum filecoin-proofs 0.6.4 (git+https://github.com/filecoin-project/rust-fil-proofs.git)" = "<none>"
-"checksum filecoin-proofs-ffi 0.7.3 (git+https://github.com/filecoin-project/rust-fil-proofs-ffi.git?branch=feat/sector-importing-api)" = "<none>"
+"checksum filecoin-proofs-ffi 0.7.3 (git+https://github.com/filecoin-project/rust-fil-proofs-ffi.git)" = "<none>"
 "checksum filetime 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6bd7380b54ced79dda72ecc35cc4fbbd1da6bba54afaa37e96fd1c2a308cd469"
 "checksum flate2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ad3c5233c9a940c8719031b423d7e6c16af66e031cb0420b0896f5245bf181d3"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
@@ -2879,6 +2885,7 @@ dependencies = [
 "checksum lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8912e782533a93a167888781b836336a6ca5da6175c05944c86cf28c31104dc"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+"checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 "checksum memoffset 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a85c1a8c329f11437034d7313dca647c79096523533a1c79e86f1d0f657c7cc"
@@ -2990,14 +2997,14 @@ dependencies = [
 "checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
-"checksum smallvec 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "533e29e15d0748f28afbaf4ff7cab44d73e483a8e50b38c40bd13b7f3d48f542"
+"checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
 "checksum storage-proofs 0.6.2 (git+https://github.com/filecoin-project/rust-fil-proofs.git)" = "<none>"
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0e7bedb3320d0f3035594b0b723c8a28d7d336a3eda3881db79e61d676fb644c"
-"checksum synstructure 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f085a5855930c0441ca1288cf044ea4aecf4f43a91668abdb870b4ba546a203"
+"checksum synstructure 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "575be94ccb86e8da37efb894a87e2b660be299b41d8ef347f9d6d79fbe61b1ba"
 "checksum tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)" = "b3196bfbffbba3e57481b6ea32249fbaf590396a52505a2615adbb79d9d826d3"
 "checksum tee 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37c12559dba7383625faaff75be24becf35bfc885044375bcab931111799a3da"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"

--- a/sector-builder-ffi/Cargo.toml
+++ b/sector-builder-ffi/Cargo.toml
@@ -18,7 +18,7 @@ drop_struct_macro_derive = "0.4.0"
 ffi-toolkit = "0.4.0"
 filecoin-proofs = { git = "https://github.com/filecoin-project/rust-fil-proofs.git", branch = "master" }
 storage-proofs = { git = "https://github.com/filecoin-project/rust-fil-proofs.git", branch = "master" }
-filecoin-proofs-ffi = { git = "https://github.com/filecoin-project/rust-fil-proofs-ffi.git", branch = "feat/sector-importing-api" }
+filecoin-proofs-ffi = { git = "https://github.com/filecoin-project/rust-fil-proofs-ffi.git", branch = "master" }
 sector-builder = { path = "../sector-builder" }
 failure = "0.1.5"
 libc = "0.2.58"

--- a/sector-builder-ffi/Cargo.toml
+++ b/sector-builder-ffi/Cargo.toml
@@ -18,7 +18,7 @@ drop_struct_macro_derive = "0.4.0"
 ffi-toolkit = "0.4.0"
 filecoin-proofs = { git = "https://github.com/filecoin-project/rust-fil-proofs.git", branch = "master" }
 storage-proofs = { git = "https://github.com/filecoin-project/rust-fil-proofs.git", branch = "master" }
-filecoin-proofs-ffi = { git = "https://github.com/filecoin-project/rust-fil-proofs-ffi.git", branch = "master" }
+filecoin-proofs-ffi = { git = "https://github.com/filecoin-project/rust-fil-proofs-ffi.git", branch = "feat/sector-importing-api" }
 sector-builder = { path = "../sector-builder" }
 failure = "0.1.5"
 libc = "0.2.58"

--- a/sector-builder-ffi/examples/simple/plumbing.rs
+++ b/sector-builder-ffi/examples/simple/plumbing.rs
@@ -47,7 +47,7 @@ pub(crate) unsafe fn verify_post(
     let flattened_comm_rs = proving_set.flattened_comm_rs();
     let faulty_sector_ids = proving_set.faulty_sector_ids();
 
-    let resp = sector_builder_ffi_verify_post(
+    let resp = sector_builder_ffi_reexported_verify_post(
         sector_size,
         &mut challenge_seed.clone(),
         sector_ids.as_ptr(),
@@ -59,7 +59,9 @@ pub(crate) unsafe fn verify_post(
         proof.as_ptr(),
         proof.len(),
     );
-    defer!(sector_builder_ffi_destroy_verify_post_response(resp));
+    defer!(sector_builder_ffi_reexported_destroy_verify_post_response(
+        resp
+    ));
 
     if (*resp).status_code != 0 {
         return Err((
@@ -200,13 +202,13 @@ pub(crate) unsafe fn generate_data_commitment(
     sector_size: u64,
     piece_info: &[sector_builder_ffi_FFIPublicPieceInfo],
 ) -> Result<[u8; 32], (sector_builder_ffi_FCPResponseStatus, String)> {
-    let resp = sector_builder_ffi_generate_data_commitment(
+    let resp = sector_builder_ffi_reexported_generate_data_commitment(
         sector_size,
         piece_info.as_ptr(),
         piece_info.len(),
     );
     defer!(ctx.destructors.push(Box::new(move || {
-        sector_builder_ffi_destroy_generate_data_commitment_response(resp);
+        sector_builder_ffi_reexported_destroy_generate_data_commitment_response(resp);
     })));
 
     if (*resp).status_code != 0 {
@@ -228,9 +230,10 @@ pub(crate) unsafe fn generate_piece_commitment(
     use std::os::unix::io::AsRawFd;
     let c_piece_fd = piece_file.as_raw_fd();
 
-    let resp = sector_builder_ffi_generate_piece_commitment(c_piece_fd, piece_len as u64);
+    let resp =
+        sector_builder_ffi_reexported_generate_piece_commitment(c_piece_fd, piece_len as u64);
     defer!(ctx.destructors.push(Box::new(move || {
-        sector_builder_ffi_destroy_generate_piece_commitment_response(resp);
+        sector_builder_ffi_reexported_destroy_generate_piece_commitment_response(resp);
     })));
 
     if (*resp).status_code != 0 {
@@ -340,7 +343,7 @@ pub(crate) unsafe fn verify_seal(
     comm_d: [u8; 32],
     prover_id: [u8; 32],
 ) -> Result<bool, (sector_builder_ffi_FCPResponseStatus, String)> {
-    let resp = sector_builder_ffi_verify_seal(
+    let resp = sector_builder_ffi_reexported_verify_seal(
         sector_size,
         &mut comm_r.clone(),
         &mut comm_d.clone(),
@@ -352,7 +355,7 @@ pub(crate) unsafe fn verify_seal(
         proof.len(),
     );
     defer!(ctx.destructors.push(Box::new(move || {
-        sector_builder_ffi_destroy_verify_seal_response(resp);
+        sector_builder_ffi_reexported_destroy_verify_seal_response(resp);
     })));
 
     if (*resp).status_code != 0 {
@@ -366,7 +369,7 @@ pub(crate) unsafe fn verify_seal(
 }
 
 pub(crate) unsafe fn get_max_user_bytes_per_staged_sector(sector_size: u64) -> u64 {
-    sector_builder_ffi_get_max_user_bytes_per_staged_sector(sector_size)
+    sector_builder_ffi_reexported_get_max_user_bytes_per_staged_sector(sector_size)
 }
 
 pub(crate) unsafe fn destroy_sector_builder(mut p: *mut sector_builder_ffi_SectorBuilder) {

--- a/sector-builder-ffi/src/api.rs
+++ b/sector-builder-ffi/src/api.rs
@@ -14,8 +14,7 @@ use storage_proofs::sector::SectorId;
 
 use crate::types::{
     self, err_code_and_msg, FFIPieceMetadata, FFISealSeed, FFISealStatus, FFISealTicket,
-    FFISealedSectorHealth, FFISealedSectorMetadata, FFISectorClass, FileDescriptorRef,
-    SectorBuilder,
+    FFISealedSectorHealth, FFISealedSectorMetadata, FileDescriptorRef, SectorBuilder,
 };
 use filecoin_proofs_ffi::types::FFIPublicPieceInfo;
 
@@ -66,7 +65,7 @@ pub unsafe extern "C" fn sector_builder_ffi_add_piece(
 /// will fit into a sector of the given size.
 ///
 #[no_mangle]
-pub unsafe extern "C" fn sector_builder_ffi_get_max_user_bytes_per_staged_sector(
+pub unsafe extern "C" fn sector_builder_ffi_reexported_get_max_user_bytes_per_staged_sector(
     sector_size: u64,
 ) -> u64 {
     init_log();
@@ -78,7 +77,7 @@ pub unsafe extern "C" fn sector_builder_ffi_get_max_user_bytes_per_staged_sector
 /// The caller is responsible for closing the file descriptor.
 #[no_mangle]
 #[cfg(not(target_os = "windows"))]
-pub unsafe extern "C" fn sector_builder_ffi_generate_piece_commitment(
+pub unsafe extern "C" fn sector_builder_ffi_reexported_generate_piece_commitment(
     piece_fd_raw: libc::c_int,
     unpadded_piece_size: u64,
 ) -> *mut filecoin_proofs_ffi::types::GeneratePieceCommitmentResponse {
@@ -303,7 +302,7 @@ pub unsafe extern "C" fn sector_builder_ffi_generate_post(
 ///
 #[no_mangle]
 pub unsafe extern "C" fn sector_builder_ffi_init_sector_builder(
-    sector_class: FFISectorClass,
+    sector_class: filecoin_proofs_ffi::types::FFISectorClass,
     last_used_sector_id: u64,
     metadata_dir: *const libc::c_char,
     prover_id: &[u8; 32],
@@ -574,7 +573,7 @@ pub unsafe extern "C" fn sector_builder_ffi_read_piece_from_sealed_sector(
 /// Verifies the output of seal.
 ///
 #[no_mangle]
-pub unsafe extern "C" fn sector_builder_ffi_verify_seal(
+pub unsafe extern "C" fn sector_builder_ffi_reexported_verify_seal(
     sector_size: u64,
     comm_r: &[u8; 32],
     comm_d: &[u8; 32],
@@ -605,7 +604,7 @@ pub unsafe extern "C" fn sector_builder_ffi_verify_seal(
 /// Generate a data commitment for a sector containing the provided pieces.
 ///
 #[no_mangle]
-pub unsafe extern "C" fn sector_builder_ffi_generate_data_commitment(
+pub unsafe extern "C" fn sector_builder_ffi_reexported_generate_data_commitment(
     sector_size: u64,
     pieces_ptr: *const FFIPublicPieceInfo,
     pieces_len: libc::size_t,
@@ -619,7 +618,7 @@ pub unsafe extern "C" fn sector_builder_ffi_generate_data_commitment(
 /// Verifies that a proof-of-spacetime is valid.
 ///
 #[no_mangle]
-pub unsafe extern "C" fn sector_builder_ffi_verify_post(
+pub unsafe extern "C" fn sector_builder_ffi_reexported_verify_post(
     sector_size: u64,
     challenge_seed: &[u8; 32],
     sector_ids_ptr: *const u64,
@@ -645,6 +644,33 @@ pub unsafe extern "C" fn sector_builder_ffi_verify_post(
             flattened_comm_rs_len,
             proof_ptr,
             proof_len,
+        )
+    })
+}
+
+/// TODO: document
+///
+#[no_mangle]
+pub unsafe extern "C" fn sector_builder_ffi_reexported_unseal(
+    sector_class: filecoin_proofs_ffi::types::FFISectorClass,
+    sealed_sector_path: *const libc::c_char,
+    unseal_output_path: *const libc::c_char,
+    sector_id: u64,
+    prover_id: &[u8; 32],
+    ticket: &[u8; 32],
+    comm_d: &[u8; 32],
+) -> *mut filecoin_proofs_ffi::types::UnsealResponse {
+    catch_panic_response(|| {
+        init_log();
+
+        filecoin_proofs_ffi::api::unseal(
+            sector_class,
+            sealed_sector_path,
+            unseal_output_path,
+            sector_id,
+            prover_id,
+            ticket,
+            comm_d,
         )
     })
 }
@@ -732,7 +758,7 @@ pub unsafe extern "C" fn sector_builder_ffi_destroy_resume_seal_commit_response(
 
 ///
 #[no_mangle]
-pub unsafe extern "C" fn sector_builder_ffi_destroy_verify_seal_response(
+pub unsafe extern "C" fn sector_builder_ffi_reexported_destroy_verify_seal_response(
     ptr: *mut filecoin_proofs_ffi::types::VerifySealResponse,
 ) {
     filecoin_proofs_ffi::api::destroy_verify_seal_response(ptr)
@@ -741,7 +767,7 @@ pub unsafe extern "C" fn sector_builder_ffi_destroy_verify_seal_response(
 /// Deallocates a VerifyPoStResponse.
 ///
 #[no_mangle]
-pub unsafe extern "C" fn sector_builder_ffi_destroy_verify_post_response(
+pub unsafe extern "C" fn sector_builder_ffi_reexported_destroy_verify_post_response(
     ptr: *mut filecoin_proofs_ffi::types::VerifyPoStResponse,
 ) {
     filecoin_proofs_ffi::api::destroy_verify_post_response(ptr)
@@ -751,7 +777,7 @@ pub unsafe extern "C" fn sector_builder_ffi_destroy_verify_post_response(
 ///
 #[no_mangle]
 #[cfg(not(target_os = "windows"))]
-pub unsafe extern "C" fn sector_builder_ffi_destroy_generate_piece_commitment_response(
+pub unsafe extern "C" fn sector_builder_ffi_reexported_destroy_generate_piece_commitment_response(
     ptr: *mut filecoin_proofs_ffi::types::GeneratePieceCommitmentResponse,
 ) {
     filecoin_proofs_ffi::api::destroy_generate_piece_commitment_response(ptr)
@@ -760,7 +786,7 @@ pub unsafe extern "C" fn sector_builder_ffi_destroy_generate_piece_commitment_re
 /// Deallocates a GenerateDataCommitmentResponse.
 ///
 #[no_mangle]
-pub unsafe extern "C" fn sector_builder_ffi_destroy_generate_data_commitment_response(
+pub unsafe extern "C" fn sector_builder_ffi_reexported_destroy_generate_data_commitment_response(
     ptr: *mut filecoin_proofs_ffi::types::GenerateDataCommitmentResponse,
 ) {
     filecoin_proofs_ffi::api::destroy_generate_data_commitment_response(ptr)
@@ -787,6 +813,13 @@ pub unsafe extern "C" fn sector_builder_ffi_destroy_seal_pre_commit_sector_respo
 #[no_mangle]
 pub unsafe extern "C" fn sector_builder_ffi_destroy_resume_seal_commit_sector_response(
     ptr: *mut types::ResumeSealCommitResponse,
+) {
+    let _ = Box::from_raw(ptr);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sector_builder_ffi_reexported_destroy_unseal_response(
+    ptr: *mut filecoin_proofs_ffi::types::UnsealResponse,
 ) {
     let _ = Box::from_raw(ptr);
 }

--- a/sector-builder-ffi/src/api.rs
+++ b/sector-builder-ffi/src/api.rs
@@ -17,7 +17,7 @@ use crate::types::{
     FFISealedSectorHealth, FFISealedSectorMetadata, FFISectorClass, FileDescriptorRef,
     SectorBuilder,
 };
-use filecoin_proofs_ffi::api::FFIPublicPieceInfo;
+use filecoin_proofs_ffi::types::FFIPublicPieceInfo;
 
 /// Writes user piece-bytes to a staged sector and returns the id of the sector
 /// to which the bytes were written.
@@ -81,7 +81,7 @@ pub unsafe extern "C" fn sector_builder_ffi_get_max_user_bytes_per_staged_sector
 pub unsafe extern "C" fn sector_builder_ffi_generate_piece_commitment(
     piece_fd_raw: libc::c_int,
     unpadded_piece_size: u64,
-) -> *mut filecoin_proofs_ffi::responses::GeneratePieceCommitmentResponse {
+) -> *mut filecoin_proofs_ffi::types::GeneratePieceCommitmentResponse {
     catch_panic_response(|| {
         init_log();
 
@@ -584,7 +584,7 @@ pub unsafe extern "C" fn sector_builder_ffi_verify_seal(
     seed: &[u8; 32],
     proof_ptr: *const u8,
     proof_len: libc::size_t,
-) -> *mut filecoin_proofs_ffi::responses::VerifySealResponse {
+) -> *mut filecoin_proofs_ffi::types::VerifySealResponse {
     catch_panic_response(|| {
         init_log();
 
@@ -609,7 +609,7 @@ pub unsafe extern "C" fn sector_builder_ffi_generate_data_commitment(
     sector_size: u64,
     pieces_ptr: *const FFIPublicPieceInfo,
     pieces_len: libc::size_t,
-) -> *mut filecoin_proofs_ffi::responses::GenerateDataCommitmentResponse {
+) -> *mut filecoin_proofs_ffi::types::GenerateDataCommitmentResponse {
     catch_panic_response(|| {
         init_log();
         filecoin_proofs_ffi::api::generate_data_commitment(sector_size, pieces_ptr, pieces_len)
@@ -630,7 +630,7 @@ pub unsafe extern "C" fn sector_builder_ffi_verify_post(
     flattened_comm_rs_len: libc::size_t,
     proof_ptr: *const u8,
     proof_len: libc::size_t,
-) -> *mut filecoin_proofs_ffi::responses::VerifyPoStResponse {
+) -> *mut filecoin_proofs_ffi::types::VerifyPoStResponse {
     catch_panic_response(|| {
         init_log();
 
@@ -733,7 +733,7 @@ pub unsafe extern "C" fn sector_builder_ffi_destroy_resume_seal_commit_response(
 ///
 #[no_mangle]
 pub unsafe extern "C" fn sector_builder_ffi_destroy_verify_seal_response(
-    ptr: *mut filecoin_proofs_ffi::responses::VerifySealResponse,
+    ptr: *mut filecoin_proofs_ffi::types::VerifySealResponse,
 ) {
     filecoin_proofs_ffi::api::destroy_verify_seal_response(ptr)
 }
@@ -742,7 +742,7 @@ pub unsafe extern "C" fn sector_builder_ffi_destroy_verify_seal_response(
 ///
 #[no_mangle]
 pub unsafe extern "C" fn sector_builder_ffi_destroy_verify_post_response(
-    ptr: *mut filecoin_proofs_ffi::responses::VerifyPoStResponse,
+    ptr: *mut filecoin_proofs_ffi::types::VerifyPoStResponse,
 ) {
     filecoin_proofs_ffi::api::destroy_verify_post_response(ptr)
 }
@@ -752,7 +752,7 @@ pub unsafe extern "C" fn sector_builder_ffi_destroy_verify_post_response(
 #[no_mangle]
 #[cfg(not(target_os = "windows"))]
 pub unsafe extern "C" fn sector_builder_ffi_destroy_generate_piece_commitment_response(
-    ptr: *mut filecoin_proofs_ffi::responses::GeneratePieceCommitmentResponse,
+    ptr: *mut filecoin_proofs_ffi::types::GeneratePieceCommitmentResponse,
 ) {
     filecoin_proofs_ffi::api::destroy_generate_piece_commitment_response(ptr)
 }
@@ -761,7 +761,7 @@ pub unsafe extern "C" fn sector_builder_ffi_destroy_generate_piece_commitment_re
 ///
 #[no_mangle]
 pub unsafe extern "C" fn sector_builder_ffi_destroy_generate_data_commitment_response(
-    ptr: *mut filecoin_proofs_ffi::responses::GenerateDataCommitmentResponse,
+    ptr: *mut filecoin_proofs_ffi::types::GenerateDataCommitmentResponse,
 ) {
     filecoin_proofs_ffi::api::destroy_generate_data_commitment_response(ptr)
 }

--- a/sector-builder-ffi/src/api.rs
+++ b/sector-builder-ffi/src/api.rs
@@ -16,7 +16,6 @@ use crate::types::{
     self, err_code_and_msg, FFIPieceMetadata, FFISealSeed, FFISealStatus, FFISealTicket,
     FFISealedSectorHealth, FFISealedSectorMetadata, FileDescriptorRef, SectorBuilder,
 };
-use filecoin_proofs_ffi::types::FFIPublicPieceInfo;
 
 /// Writes user piece-bytes to a staged sector and returns the id of the sector
 /// to which the bytes were written.
@@ -58,33 +57,6 @@ pub unsafe extern "C" fn sector_builder_ffi_add_piece(
         info!("add_piece: {}", "finish");
 
         raw_ptr(response)
-    })
-}
-
-/// Returns the number of user bytes (before bit-padding has been added) which
-/// will fit into a sector of the given size.
-///
-#[no_mangle]
-pub unsafe extern "C" fn sector_builder_ffi_reexported_get_max_user_bytes_per_staged_sector(
-    sector_size: u64,
-) -> u64 {
-    init_log();
-
-    filecoin_proofs_ffi::api::get_max_user_bytes_per_staged_sector(sector_size)
-}
-
-/// Returns the merkle root for a piece after piece padding and alignment.
-/// The caller is responsible for closing the file descriptor.
-#[no_mangle]
-#[cfg(not(target_os = "windows"))]
-pub unsafe extern "C" fn sector_builder_ffi_reexported_generate_piece_commitment(
-    piece_fd_raw: libc::c_int,
-    unpadded_piece_size: u64,
-) -> *mut filecoin_proofs_ffi::types::GeneratePieceCommitmentResponse {
-    catch_panic_response(|| {
-        init_log();
-
-        filecoin_proofs_ffi::api::generate_piece_commitment(piece_fd_raw, unpadded_piece_size)
     })
 }
 
@@ -570,213 +542,6 @@ pub unsafe extern "C" fn sector_builder_ffi_read_piece_from_sealed_sector(
     })
 }
 
-/// Verifies the output of seal.
-///
-#[no_mangle]
-pub unsafe extern "C" fn sector_builder_ffi_reexported_verify_seal(
-    sector_size: u64,
-    comm_r: &[u8; 32],
-    comm_d: &[u8; 32],
-    prover_id: &[u8; 32],
-    sector_id: u64,
-    ticket: &[u8; 32],
-    seed: &[u8; 32],
-    proof_ptr: *const u8,
-    proof_len: libc::size_t,
-) -> *mut filecoin_proofs_ffi::types::VerifySealResponse {
-    catch_panic_response(|| {
-        init_log();
-
-        filecoin_proofs_ffi::api::verify_seal(
-            sector_size,
-            comm_r,
-            comm_d,
-            prover_id,
-            ticket,
-            seed,
-            sector_id,
-            proof_ptr,
-            proof_len,
-        )
-    })
-}
-
-/// Generate a data commitment for a sector containing the provided pieces.
-///
-#[no_mangle]
-pub unsafe extern "C" fn sector_builder_ffi_reexported_generate_data_commitment(
-    sector_size: u64,
-    pieces_ptr: *const FFIPublicPieceInfo,
-    pieces_len: libc::size_t,
-) -> *mut filecoin_proofs_ffi::types::GenerateDataCommitmentResponse {
-    catch_panic_response(|| {
-        init_log();
-        filecoin_proofs_ffi::api::generate_data_commitment(sector_size, pieces_ptr, pieces_len)
-    })
-}
-
-/// Verifies that a proof-of-spacetime is valid.
-///
-#[no_mangle]
-pub unsafe extern "C" fn sector_builder_ffi_reexported_verify_post(
-    sector_size: u64,
-    challenge_seed: &[u8; 32],
-    sector_ids_ptr: *const u64,
-    sector_ids_len: libc::size_t,
-    faulty_sector_ids_ptr: *const u64,
-    faulty_sector_ids_len: libc::size_t,
-    flattened_comm_rs_ptr: *const u8,
-    flattened_comm_rs_len: libc::size_t,
-    proof_ptr: *const u8,
-    proof_len: libc::size_t,
-) -> *mut filecoin_proofs_ffi::types::VerifyPoStResponse {
-    catch_panic_response(|| {
-        init_log();
-
-        filecoin_proofs_ffi::api::verify_post(
-            sector_size,
-            challenge_seed,
-            sector_ids_ptr,
-            sector_ids_len,
-            faulty_sector_ids_ptr,
-            faulty_sector_ids_len,
-            flattened_comm_rs_ptr,
-            flattened_comm_rs_len,
-            proof_ptr,
-            proof_len,
-        )
-    })
-}
-
-/// TODO: document
-///
-#[no_mangle]
-#[cfg(not(target_os = "windows"))]
-pub unsafe extern "C" fn sector_builder_ffi_reexported_write_with_alignment(
-    src_fd: libc::c_int,
-    src_size: u64,
-    dst_fd: libc::c_int,
-    existing_piece_sizes_ptr: *const u64,
-    existing_piece_sizes_len: libc::size_t,
-) -> *mut filecoin_proofs_ffi::types::WriteWithAlignmentResponse {
-    catch_panic_response(|| {
-        init_log();
-
-        filecoin_proofs_ffi::api::write_with_alignment(
-            src_fd,
-            src_size,
-            dst_fd,
-            existing_piece_sizes_ptr,
-            existing_piece_sizes_len,
-        )
-    })
-}
-
-/// TODO: document
-///
-#[no_mangle]
-#[cfg(not(target_os = "windows"))]
-pub unsafe extern "C" fn sector_builder_ffi_reexported_write_without_alignment(
-    src_fd: libc::c_int,
-    src_size: u64,
-    dst_fd: libc::c_int,
-) -> *mut filecoin_proofs_ffi::types::WriteWithoutAlignmentResponse {
-    catch_panic_response(|| {
-        init_log();
-
-        filecoin_proofs_ffi::api::write_without_alignment(src_fd, src_size, dst_fd)
-    })
-}
-
-/// TODO: document
-///
-#[no_mangle]
-pub unsafe extern "C" fn sector_builder_ffi_reexported_seal_pre_commit(
-    sector_class: filecoin_proofs_ffi::types::FFISectorClass,
-    cache_dir_path: *const libc::c_char,
-    staged_sector_path: *const libc::c_char,
-    sealed_sector_path: *const libc::c_char,
-    sector_id: u64,
-    prover_id: &[u8; 32],
-    ticket: &[u8; 32],
-    pieces_ptr: *const FFIPublicPieceInfo,
-    pieces_len: libc::size_t,
-) -> *mut filecoin_proofs_ffi::types::SealPreCommitResponse {
-    catch_panic_response(|| {
-        init_log();
-
-        filecoin_proofs_ffi::api::seal_pre_commit(
-            sector_class,
-            cache_dir_path,
-            staged_sector_path,
-            sealed_sector_path,
-            sector_id,
-            prover_id,
-            ticket,
-            pieces_ptr,
-            pieces_len,
-        )
-    })
-}
-
-/// TODO: document
-///
-#[no_mangle]
-pub unsafe extern "C" fn sector_builder_ffi_reexported_seal_commit(
-    sector_class: filecoin_proofs_ffi::types::FFISectorClass,
-    cache_dir_path: *const libc::c_char,
-    sector_id: u64,
-    prover_id: &[u8; 32],
-    ticket: &[u8; 32],
-    seed: &[u8; 32],
-    pieces_ptr: *const filecoin_proofs_ffi::types::FFIPublicPieceInfo,
-    pieces_len: libc::size_t,
-    spco: filecoin_proofs_ffi::types::FFISealPreCommitOutput,
-) -> *mut filecoin_proofs_ffi::types::SealCommitResponse {
-    catch_panic_response(|| {
-        init_log();
-
-        filecoin_proofs_ffi::api::seal_commit(
-            sector_class,
-            cache_dir_path,
-            sector_id,
-            prover_id,
-            ticket,
-            seed,
-            pieces_ptr,
-            pieces_len,
-            spco,
-        )
-    })
-}
-
-/// TODO: document
-///
-#[no_mangle]
-pub unsafe extern "C" fn sector_builder_ffi_reexported_unseal(
-    sector_class: filecoin_proofs_ffi::types::FFISectorClass,
-    sealed_sector_path: *const libc::c_char,
-    unseal_output_path: *const libc::c_char,
-    sector_id: u64,
-    prover_id: &[u8; 32],
-    ticket: &[u8; 32],
-    comm_d: &[u8; 32],
-) -> *mut filecoin_proofs_ffi::types::UnsealResponse {
-    catch_panic_response(|| {
-        init_log();
-
-        filecoin_proofs_ffi::api::unseal(
-            sector_class,
-            sealed_sector_path,
-            unseal_output_path,
-            sector_id,
-            prover_id,
-            ticket,
-            comm_d,
-        )
-    })
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 // DESTRUCTORS
 //////////////
@@ -858,42 +623,6 @@ pub unsafe extern "C" fn sector_builder_ffi_destroy_resume_seal_commit_response(
     let _ = Box::from_raw(ptr);
 }
 
-///
-#[no_mangle]
-pub unsafe extern "C" fn sector_builder_ffi_reexported_destroy_verify_seal_response(
-    ptr: *mut filecoin_proofs_ffi::types::VerifySealResponse,
-) {
-    filecoin_proofs_ffi::api::destroy_verify_seal_response(ptr)
-}
-
-/// Deallocates a VerifyPoStResponse.
-///
-#[no_mangle]
-pub unsafe extern "C" fn sector_builder_ffi_reexported_destroy_verify_post_response(
-    ptr: *mut filecoin_proofs_ffi::types::VerifyPoStResponse,
-) {
-    filecoin_proofs_ffi::api::destroy_verify_post_response(ptr)
-}
-
-/// Deallocates a GeneratePieceCommitmentResponse.
-///
-#[no_mangle]
-#[cfg(not(target_os = "windows"))]
-pub unsafe extern "C" fn sector_builder_ffi_reexported_destroy_generate_piece_commitment_response(
-    ptr: *mut filecoin_proofs_ffi::types::GeneratePieceCommitmentResponse,
-) {
-    filecoin_proofs_ffi::api::destroy_generate_piece_commitment_response(ptr)
-}
-
-/// Deallocates a GenerateDataCommitmentResponse.
-///
-#[no_mangle]
-pub unsafe extern "C" fn sector_builder_ffi_reexported_destroy_generate_data_commitment_response(
-    ptr: *mut filecoin_proofs_ffi::types::GenerateDataCommitmentResponse,
-) {
-    filecoin_proofs_ffi::api::destroy_generate_data_commitment_response(ptr)
-}
-
 /// Destroys a SectorBuilder.
 ///
 #[no_mangle]
@@ -915,41 +644,6 @@ pub unsafe extern "C" fn sector_builder_ffi_destroy_seal_pre_commit_sector_respo
 #[no_mangle]
 pub unsafe extern "C" fn sector_builder_ffi_destroy_resume_seal_commit_sector_response(
     ptr: *mut types::ResumeSealCommitResponse,
-) {
-    let _ = Box::from_raw(ptr);
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn sector_builder_ffi_reexported_destroy_unseal_response(
-    ptr: *mut filecoin_proofs_ffi::types::UnsealResponse,
-) {
-    let _ = Box::from_raw(ptr);
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn sector_builder_ffi_reexported_destroy_seal_commit_response(
-    ptr: *mut filecoin_proofs_ffi::types::SealCommitResponse,
-) {
-    let _ = Box::from_raw(ptr);
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn sector_builder_ffi_reexported_destroy_seal_pre_commit_response(
-    ptr: *mut filecoin_proofs_ffi::types::SealPreCommitResponse,
-) {
-    let _ = Box::from_raw(ptr);
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn sector_builder_ffi_reexported_destroy_write_without_alignment_response(
-    ptr: *mut filecoin_proofs_ffi::types::WriteWithoutAlignmentResponse,
-) {
-    let _ = Box::from_raw(ptr);
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn sector_builder_ffi_reexported_destroy_write_with_alignment_response(
-    ptr: *mut filecoin_proofs_ffi::types::WriteWithAlignmentResponse,
 ) {
     let _ = Box::from_raw(ptr);
 }
@@ -978,7 +672,7 @@ unsafe fn into_commitments(
 static LOG_INIT: OnceCell<bool> = OnceCell::new();
 
 /// Ensures the logger is initialized.
-fn init_log() {
+pub(crate) fn init_log() {
     LOG_INIT.get_or_init(|| {
         let _ = pretty_env_logger::try_init_timed();
         true

--- a/sector-builder-ffi/src/api.rs
+++ b/sector-builder-ffi/src/api.rs
@@ -651,6 +651,108 @@ pub unsafe extern "C" fn sector_builder_ffi_reexported_verify_post(
 /// TODO: document
 ///
 #[no_mangle]
+#[cfg(not(target_os = "windows"))]
+pub unsafe extern "C" fn sector_builder_ffi_reexported_write_with_alignment(
+    src_fd: libc::c_int,
+    src_size: u64,
+    dst_fd: libc::c_int,
+    existing_piece_sizes_ptr: *const u64,
+    existing_piece_sizes_len: libc::size_t,
+) -> *mut filecoin_proofs_ffi::types::WriteWithAlignmentResponse {
+    catch_panic_response(|| {
+        init_log();
+
+        filecoin_proofs_ffi::api::write_with_alignment(
+            src_fd,
+            src_size,
+            dst_fd,
+            existing_piece_sizes_ptr,
+            existing_piece_sizes_len,
+        )
+    })
+}
+
+/// TODO: document
+///
+#[no_mangle]
+#[cfg(not(target_os = "windows"))]
+pub unsafe extern "C" fn sector_builder_ffi_reexported_write_without_alignment(
+    src_fd: libc::c_int,
+    src_size: u64,
+    dst_fd: libc::c_int,
+) -> *mut filecoin_proofs_ffi::types::WriteWithoutAlignmentResponse {
+    catch_panic_response(|| {
+        init_log();
+
+        filecoin_proofs_ffi::api::write_without_alignment(src_fd, src_size, dst_fd)
+    })
+}
+
+/// TODO: document
+///
+#[no_mangle]
+pub unsafe extern "C" fn sector_builder_ffi_reexported_seal_pre_commit(
+    sector_class: filecoin_proofs_ffi::types::FFISectorClass,
+    cache_dir_path: *const libc::c_char,
+    staged_sector_path: *const libc::c_char,
+    sealed_sector_path: *const libc::c_char,
+    sector_id: u64,
+    prover_id: &[u8; 32],
+    ticket: &[u8; 32],
+    pieces_ptr: *const FFIPublicPieceInfo,
+    pieces_len: libc::size_t,
+) -> *mut filecoin_proofs_ffi::types::SealPreCommitResponse {
+    catch_panic_response(|| {
+        init_log();
+
+        filecoin_proofs_ffi::api::seal_pre_commit(
+            sector_class,
+            cache_dir_path,
+            staged_sector_path,
+            sealed_sector_path,
+            sector_id,
+            prover_id,
+            ticket,
+            pieces_ptr,
+            pieces_len,
+        )
+    })
+}
+
+/// TODO: document
+///
+#[no_mangle]
+pub unsafe extern "C" fn sector_builder_ffi_reexported_seal_commit(
+    sector_class: filecoin_proofs_ffi::types::FFISectorClass,
+    cache_dir_path: *const libc::c_char,
+    sector_id: u64,
+    prover_id: &[u8; 32],
+    ticket: &[u8; 32],
+    seed: &[u8; 32],
+    pieces_ptr: *const filecoin_proofs_ffi::types::FFIPublicPieceInfo,
+    pieces_len: libc::size_t,
+    spco: filecoin_proofs_ffi::types::FFISealPreCommitOutput,
+) -> *mut filecoin_proofs_ffi::types::SealCommitResponse {
+    catch_panic_response(|| {
+        init_log();
+
+        filecoin_proofs_ffi::api::seal_commit(
+            sector_class,
+            cache_dir_path,
+            sector_id,
+            prover_id,
+            ticket,
+            seed,
+            pieces_ptr,
+            pieces_len,
+            spco,
+        )
+    })
+}
+
+/// TODO: document
+///
+#[no_mangle]
 pub unsafe extern "C" fn sector_builder_ffi_reexported_unseal(
     sector_class: filecoin_proofs_ffi::types::FFISectorClass,
     sealed_sector_path: *const libc::c_char,
@@ -820,6 +922,34 @@ pub unsafe extern "C" fn sector_builder_ffi_destroy_resume_seal_commit_sector_re
 #[no_mangle]
 pub unsafe extern "C" fn sector_builder_ffi_reexported_destroy_unseal_response(
     ptr: *mut filecoin_proofs_ffi::types::UnsealResponse,
+) {
+    let _ = Box::from_raw(ptr);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sector_builder_ffi_reexported_destroy_seal_commit_response(
+    ptr: *mut filecoin_proofs_ffi::types::SealCommitResponse,
+) {
+    let _ = Box::from_raw(ptr);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sector_builder_ffi_reexported_destroy_seal_pre_commit_response(
+    ptr: *mut filecoin_proofs_ffi::types::SealPreCommitResponse,
+) {
+    let _ = Box::from_raw(ptr);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sector_builder_ffi_reexported_destroy_write_without_alignment_response(
+    ptr: *mut filecoin_proofs_ffi::types::WriteWithoutAlignmentResponse,
+) {
+    let _ = Box::from_raw(ptr);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sector_builder_ffi_reexported_destroy_write_with_alignment_response(
+    ptr: *mut filecoin_proofs_ffi::types::WriteWithAlignmentResponse,
 ) {
     let _ = Box::from_raw(ptr);
 }

--- a/sector-builder-ffi/src/lib.rs
+++ b/sector-builder-ffi/src/lib.rs
@@ -5,4 +5,5 @@
 extern crate log;
 
 pub mod api;
+pub mod reexported;
 pub mod types;

--- a/sector-builder-ffi/src/reexported.rs
+++ b/sector-builder-ffi/src/reexported.rs
@@ -1,0 +1,305 @@
+use ffi_toolkit::catch_panic_response;
+
+/// Returns the number of user bytes (before bit-padding has been added) which
+/// will fit into a sector of the given size.
+///
+#[no_mangle]
+pub unsafe extern "C" fn sector_builder_ffi_reexported_get_max_user_bytes_per_staged_sector(
+    sector_size: u64,
+) -> u64 {
+    crate::api::init_log();
+
+    filecoin_proofs_ffi::api::get_max_user_bytes_per_staged_sector(sector_size)
+}
+
+/// Returns the merkle root for a piece after piece padding and alignment.
+/// The caller is responsible for closing the file descriptor.
+#[no_mangle]
+#[cfg(not(target_os = "windows"))]
+pub unsafe extern "C" fn sector_builder_ffi_reexported_generate_piece_commitment(
+    piece_fd_raw: libc::c_int,
+    unpadded_piece_size: u64,
+) -> *mut filecoin_proofs_ffi::types::GeneratePieceCommitmentResponse {
+    catch_panic_response(|| {
+        crate::api::init_log();
+
+        filecoin_proofs_ffi::api::generate_piece_commitment(piece_fd_raw, unpadded_piece_size)
+    })
+}
+
+/// Verifies the output of seal.
+///
+#[no_mangle]
+pub unsafe extern "C" fn sector_builder_ffi_reexported_verify_seal(
+    sector_size: u64,
+    comm_r: &[u8; 32],
+    comm_d: &[u8; 32],
+    prover_id: &[u8; 32],
+    sector_id: u64,
+    ticket: &[u8; 32],
+    seed: &[u8; 32],
+    proof_ptr: *const u8,
+    proof_len: libc::size_t,
+) -> *mut filecoin_proofs_ffi::types::VerifySealResponse {
+    catch_panic_response(|| {
+        crate::api::init_log();
+
+        filecoin_proofs_ffi::api::verify_seal(
+            sector_size,
+            comm_r,
+            comm_d,
+            prover_id,
+            ticket,
+            seed,
+            sector_id,
+            proof_ptr,
+            proof_len,
+        )
+    })
+}
+
+/// Generate a data commitment for a sector containing the provided pieces.
+///
+#[no_mangle]
+pub unsafe extern "C" fn sector_builder_ffi_reexported_generate_data_commitment(
+    sector_size: u64,
+    pieces_ptr: *const filecoin_proofs_ffi::types::FFIPublicPieceInfo,
+    pieces_len: libc::size_t,
+) -> *mut filecoin_proofs_ffi::types::GenerateDataCommitmentResponse {
+    catch_panic_response(|| {
+        crate::api::init_log();
+        filecoin_proofs_ffi::api::generate_data_commitment(sector_size, pieces_ptr, pieces_len)
+    })
+}
+
+/// Verifies that a proof-of-spacetime is valid.
+///
+#[no_mangle]
+pub unsafe extern "C" fn sector_builder_ffi_reexported_verify_post(
+    sector_size: u64,
+    challenge_seed: &[u8; 32],
+    sector_ids_ptr: *const u64,
+    sector_ids_len: libc::size_t,
+    faulty_sector_ids_ptr: *const u64,
+    faulty_sector_ids_len: libc::size_t,
+    flattened_comm_rs_ptr: *const u8,
+    flattened_comm_rs_len: libc::size_t,
+    proof_ptr: *const u8,
+    proof_len: libc::size_t,
+) -> *mut filecoin_proofs_ffi::types::VerifyPoStResponse {
+    catch_panic_response(|| {
+        crate::api::init_log();
+
+        filecoin_proofs_ffi::api::verify_post(
+            sector_size,
+            challenge_seed,
+            sector_ids_ptr,
+            sector_ids_len,
+            faulty_sector_ids_ptr,
+            faulty_sector_ids_len,
+            flattened_comm_rs_ptr,
+            flattened_comm_rs_len,
+            proof_ptr,
+            proof_len,
+        )
+    })
+}
+
+/// TODO: document
+///
+#[no_mangle]
+#[cfg(not(target_os = "windows"))]
+pub unsafe extern "C" fn sector_builder_ffi_reexported_write_with_alignment(
+    src_fd: libc::c_int,
+    src_size: u64,
+    dst_fd: libc::c_int,
+    existing_piece_sizes_ptr: *const u64,
+    existing_piece_sizes_len: libc::size_t,
+) -> *mut filecoin_proofs_ffi::types::WriteWithAlignmentResponse {
+    catch_panic_response(|| {
+        crate::api::init_log();
+
+        filecoin_proofs_ffi::api::write_with_alignment(
+            src_fd,
+            src_size,
+            dst_fd,
+            existing_piece_sizes_ptr,
+            existing_piece_sizes_len,
+        )
+    })
+}
+
+/// TODO: document
+///
+#[no_mangle]
+#[cfg(not(target_os = "windows"))]
+pub unsafe extern "C" fn sector_builder_ffi_reexported_write_without_alignment(
+    src_fd: libc::c_int,
+    src_size: u64,
+    dst_fd: libc::c_int,
+) -> *mut filecoin_proofs_ffi::types::WriteWithoutAlignmentResponse {
+    catch_panic_response(|| {
+        crate::api::init_log();
+
+        filecoin_proofs_ffi::api::write_without_alignment(src_fd, src_size, dst_fd)
+    })
+}
+
+/// TODO: document
+///
+#[no_mangle]
+pub unsafe extern "C" fn sector_builder_ffi_reexported_seal_pre_commit(
+    sector_class: filecoin_proofs_ffi::types::FFISectorClass,
+    cache_dir_path: *const libc::c_char,
+    staged_sector_path: *const libc::c_char,
+    sealed_sector_path: *const libc::c_char,
+    sector_id: u64,
+    prover_id: &[u8; 32],
+    ticket: &[u8; 32],
+    pieces_ptr: *const filecoin_proofs_ffi::types::FFIPublicPieceInfo,
+    pieces_len: libc::size_t,
+) -> *mut filecoin_proofs_ffi::types::SealPreCommitResponse {
+    catch_panic_response(|| {
+        crate::api::init_log();
+
+        filecoin_proofs_ffi::api::seal_pre_commit(
+            sector_class,
+            cache_dir_path,
+            staged_sector_path,
+            sealed_sector_path,
+            sector_id,
+            prover_id,
+            ticket,
+            pieces_ptr,
+            pieces_len,
+        )
+    })
+}
+
+/// TODO: document
+///
+#[no_mangle]
+pub unsafe extern "C" fn sector_builder_ffi_reexported_seal_commit(
+    sector_class: filecoin_proofs_ffi::types::FFISectorClass,
+    cache_dir_path: *const libc::c_char,
+    sector_id: u64,
+    prover_id: &[u8; 32],
+    ticket: &[u8; 32],
+    seed: &[u8; 32],
+    pieces_ptr: *const filecoin_proofs_ffi::types::FFIPublicPieceInfo,
+    pieces_len: libc::size_t,
+    spco: filecoin_proofs_ffi::types::FFISealPreCommitOutput,
+) -> *mut filecoin_proofs_ffi::types::SealCommitResponse {
+    catch_panic_response(|| {
+        crate::api::init_log();
+
+        filecoin_proofs_ffi::api::seal_commit(
+            sector_class,
+            cache_dir_path,
+            sector_id,
+            prover_id,
+            ticket,
+            seed,
+            pieces_ptr,
+            pieces_len,
+            spco,
+        )
+    })
+}
+
+/// TODO: document
+///
+#[no_mangle]
+pub unsafe extern "C" fn sector_builder_ffi_reexported_unseal(
+    sector_class: filecoin_proofs_ffi::types::FFISectorClass,
+    sealed_sector_path: *const libc::c_char,
+    unseal_output_path: *const libc::c_char,
+    sector_id: u64,
+    prover_id: &[u8; 32],
+    ticket: &[u8; 32],
+    comm_d: &[u8; 32],
+) -> *mut filecoin_proofs_ffi::types::UnsealResponse {
+    catch_panic_response(|| {
+        crate::api::init_log();
+
+        filecoin_proofs_ffi::api::unseal(
+            sector_class,
+            sealed_sector_path,
+            unseal_output_path,
+            sector_id,
+            prover_id,
+            ticket,
+            comm_d,
+        )
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sector_builder_ffi_reexported_destroy_verify_seal_response(
+    ptr: *mut filecoin_proofs_ffi::types::VerifySealResponse,
+) {
+    filecoin_proofs_ffi::api::destroy_verify_seal_response(ptr)
+}
+
+/// Deallocates a VerifyPoStResponse.
+///
+#[no_mangle]
+pub unsafe extern "C" fn sector_builder_ffi_reexported_destroy_verify_post_response(
+    ptr: *mut filecoin_proofs_ffi::types::VerifyPoStResponse,
+) {
+    filecoin_proofs_ffi::api::destroy_verify_post_response(ptr)
+}
+
+/// Deallocates a GeneratePieceCommitmentResponse.
+///
+#[no_mangle]
+#[cfg(not(target_os = "windows"))]
+pub unsafe extern "C" fn sector_builder_ffi_reexported_destroy_generate_piece_commitment_response(
+    ptr: *mut filecoin_proofs_ffi::types::GeneratePieceCommitmentResponse,
+) {
+    filecoin_proofs_ffi::api::destroy_generate_piece_commitment_response(ptr)
+}
+
+/// Deallocates a GenerateDataCommitmentResponse.
+///
+#[no_mangle]
+pub unsafe extern "C" fn sector_builder_ffi_reexported_destroy_generate_data_commitment_response(
+    ptr: *mut filecoin_proofs_ffi::types::GenerateDataCommitmentResponse,
+) {
+    filecoin_proofs_ffi::api::destroy_generate_data_commitment_response(ptr)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sector_builder_ffi_reexported_destroy_unseal_response(
+    ptr: *mut filecoin_proofs_ffi::types::UnsealResponse,
+) {
+    let _ = Box::from_raw(ptr);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sector_builder_ffi_reexported_destroy_seal_commit_response(
+    ptr: *mut filecoin_proofs_ffi::types::SealCommitResponse,
+) {
+    let _ = Box::from_raw(ptr);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sector_builder_ffi_reexported_destroy_seal_pre_commit_response(
+    ptr: *mut filecoin_proofs_ffi::types::SealPreCommitResponse,
+) {
+    let _ = Box::from_raw(ptr);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sector_builder_ffi_reexported_destroy_write_without_alignment_response(
+    ptr: *mut filecoin_proofs_ffi::types::WriteWithoutAlignmentResponse,
+) {
+    let _ = Box::from_raw(ptr);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sector_builder_ffi_reexported_destroy_write_with_alignment_response(
+    ptr: *mut filecoin_proofs_ffi::types::WriteWithAlignmentResponse,
+) {
+    let _ = Box::from_raw(ptr);
+}

--- a/sector-builder-ffi/src/types.rs
+++ b/sector-builder-ffi/src/types.rs
@@ -8,8 +8,8 @@ use failure::Error;
 use ffi_toolkit::{
     code_and_message_impl, free_c_str, rust_str_to_c_str, CodeAndMessage, FCPResponseStatus,
 };
-use filecoin_proofs::SectorClass;
 use libc;
+
 use sector_builder::{
     PieceMetadata, SealSeed, SealStatus, SealTicket, SealedSectorHealth, SealedSectorMetadata,
     SectorBuilderErr, SectorManagerErr,
@@ -530,26 +530,6 @@ impl Default for GetStagedSectorsResponse {
 }
 
 code_and_message_impl!(GetStagedSectorsResponse);
-
-#[repr(C)]
-pub struct FFISectorClass {
-    sector_size: u64,
-    porep_proof_partitions: u8,
-}
-
-impl From<FFISectorClass> for SectorClass {
-    fn from(fsc: FFISectorClass) -> Self {
-        let FFISectorClass {
-            sector_size,
-            porep_proof_partitions,
-        } = fsc;
-
-        SectorClass(
-            filecoin_proofs::SectorSize(sector_size),
-            filecoin_proofs::PoRepProofPartitions(porep_proof_partitions),
-        )
-    }
-}
 
 pub type SectorBuilder = sector_builder::SectorBuilder<FileDescriptorRef>;
 


### PR DESCRIPTION
## What's in this PR?

This changeset reexports the proofs primitive operations [introduced here](https://github.com/filecoin-project/rust-fil-proofs-ffi/pull/34/files).