### PR TITLE
feat(import): import a sealed sector

### DIFF
--- a/sector-builder-ffi/src/api.rs
+++ b/sector-builder-ffi/src/api.rs
@@ -578,14 +578,14 @@ pub unsafe extern "C" fn sector_builder_ffi_import_sealed_sector(
 
         if comm_r_last.is_err() {
             response.status_code = FCPResponseStatus::FCPUnclassifiedError;
-            response.error_msg = rust_str_to_c_str("cannot xform comm_r_last to PedersenDomain");
+            response.error_msg = rust_str_to_c_str("cannot convert comm_r_last to PedersenDomain");
             info!("seal_commit: finish");
             return raw_ptr(response);
         }
 
         if comm_c.is_err() {
             response.status_code = FCPResponseStatus::FCPUnclassifiedError;
-            response.error_msg = rust_str_to_c_str("cannot xform comm_c to PedersenDomain");
+            response.error_msg = rust_str_to_c_str("cannot convert comm_c to PedersenDomain");
             info!("seal_commit: finish");
             return raw_ptr(response);
         }

--- a/sector-builder-ffi/src/api.rs
+++ b/sector-builder-ffi/src/api.rs
@@ -590,6 +590,9 @@ pub unsafe extern "C" fn sector_builder_ffi_import_sealed_sector(
             return raw_ptr(response);
         }
 
+        // copy bytes from the provided pointer to Rust-managed space
+        let proof = std::slice::from_raw_parts(proof_ptr, proof_len).to_vec();
+
         let pieces: Vec<PieceMetadata> = Vec::from_raw_parts(pieces_ptr, pieces_len, pieces_len)
             .iter()
             .map(|meta| PieceMetadata {
@@ -612,7 +615,7 @@ pub unsafe extern "C" fn sector_builder_ffi_import_sealed_sector(
                 comm_r_last: comm_r_last.unwrap(),
             },
             pieces,
-            Vec::from_raw_parts(proof_ptr, proof_len, proof_len).to_vec(),
+            proof,
         ) {
             Ok(_) => {
                 response.status_code = FCPResponseStatus::FCPNoError;

--- a/sector-builder-ffi/src/api.rs
+++ b/sector-builder-ffi/src/api.rs
@@ -612,10 +612,7 @@ pub unsafe extern "C" fn sector_builder_ffi_import_sealed_sector(
                 comm_r_last: comm_r_last.unwrap(),
             },
             pieces,
-            Vec::from_raw_parts(proof_ptr, proof_len, proof_len)
-                .iter()
-                .cloned()
-                .collect(),
+            Vec::from_raw_parts(proof_ptr, proof_len, proof_len).to_vec(),
         ) {
             Ok(_) => {
                 response.status_code = FCPResponseStatus::FCPNoError;

--- a/sector-builder-ffi/src/api.rs
+++ b/sector-builder-ffi/src/api.rs
@@ -593,12 +593,13 @@ pub unsafe extern "C" fn sector_builder_ffi_import_sealed_sector(
         // copy bytes from the provided pointer to Rust-managed space
         let proof = std::slice::from_raw_parts(proof_ptr, proof_len).to_vec();
 
-        let pieces: Vec<PieceMetadata> = Vec::from_raw_parts(pieces_ptr, pieces_len, pieces_len)
+        // map FFIPieceMetadata to PieceMetadata so caller can dealloc
+        let pieces = std::slice::from_raw_parts(pieces_ptr, pieces_len)
             .iter()
-            .map(|meta| PieceMetadata {
-                piece_key: c_str_to_rust_str(meta.piece_key).to_string(),
-                num_bytes: UnpaddedBytesAmount(meta.num_bytes),
-                comm_p: meta.comm_p,
+            .map(|x| PieceMetadata {
+                piece_key: c_str_to_rust_str(x.piece_key).into_owned(),
+                num_bytes: UnpaddedBytesAmount(x.num_bytes),
+                comm_p: x.comm_p,
             })
             .collect();
 

--- a/sector-builder-ffi/src/api.rs
+++ b/sector-builder-ffi/src/api.rs
@@ -4,18 +4,22 @@ use std::slice::from_raw_parts;
 
 // The `CodeAndMessage` trait is needed for `catch_panic_response`
 use ffi_toolkit::{
-    c_str_to_rust_str, catch_panic_response, raw_ptr, rust_str_to_c_str, CodeAndMessage,
-    FCPResponseStatus,
+    c_str_to_pbuf, c_str_to_rust_str, catch_panic_response, raw_ptr, rust_str_to_c_str,
+    CodeAndMessage, FCPResponseStatus,
 };
 use libc;
 use once_cell::sync::OnceCell;
-use sector_builder::{GetSealedSectorResult, SealStatus, SecondsSinceEpoch};
+use sector_builder::{GetSealedSectorResult, PieceMetadata, SealStatus, SecondsSinceEpoch};
 use storage_proofs::sector::SectorId;
 
 use crate::types::{
     self, err_code_and_msg, FFIPieceMetadata, FFISealSeed, FFISealStatus, FFISealTicket,
     FFISealedSectorHealth, FFISealedSectorMetadata, FileDescriptorRef, SectorBuilder,
 };
+use filecoin_proofs::UnpaddedBytesAmount;
+use storage_proofs::hasher::pedersen::PedersenDomain;
+use storage_proofs::hasher::Domain;
+use storage_proofs::stacked::PersistentAux;
 
 /// Writes user piece-bytes to a staged sector and returns the id of the sector
 /// to which the bytes were written.
@@ -542,6 +546,120 @@ pub unsafe extern "C" fn sector_builder_ffi_read_piece_from_sealed_sector(
     })
 }
 
+/// Imports a sector sealed elsewhere and takes ownership of its metadata,
+/// cache directory, and sealed sector file.
+///
+#[no_mangle]
+pub unsafe extern "C" fn sector_builder_ffi_import_sealed_sector(
+    ptr: *mut SectorBuilder,
+    sector_id: u64,
+    sector_cache_dir_path: *const libc::c_char,
+    sealed_sector_path: *const libc::c_char,
+    seal_ticket: FFISealTicket,
+    seal_seed: FFISealSeed,
+    comm_r: &[u8; 32],
+    comm_d: &[u8; 32],
+    p_aux_comm_c: &[u8; 32],
+    p_aux_comm_r_last: &[u8; 32],
+    proof_ptr: *mut u8,
+    proof_len: libc::size_t,
+    pieces_ptr: *mut FFIPieceMetadata,
+    pieces_len: libc::size_t,
+) -> *mut types::ImportSealedSectorResponse {
+    catch_panic_response(|| {
+        init_log();
+
+        info!("import_sealed_sector: {}", "start");
+
+        let mut response: types::ImportSealedSectorResponse = Default::default();
+
+        let comm_r_last = PedersenDomain::try_from_bytes(p_aux_comm_r_last);
+        let comm_c = PedersenDomain::try_from_bytes(p_aux_comm_c);
+
+        if comm_r_last.is_err() {
+            response.status_code = FCPResponseStatus::FCPUnclassifiedError;
+            response.error_msg = rust_str_to_c_str("cannot xform comm_r_last to PedersenDomain");
+            info!("seal_commit: finish");
+            return raw_ptr(response);
+        }
+
+        if comm_c.is_err() {
+            response.status_code = FCPResponseStatus::FCPUnclassifiedError;
+            response.error_msg = rust_str_to_c_str("cannot xform comm_c to PedersenDomain");
+            info!("seal_commit: finish");
+            return raw_ptr(response);
+        }
+
+        let pieces: Vec<PieceMetadata> = Vec::from_raw_parts(pieces_ptr, pieces_len, pieces_len)
+            .iter()
+            .map(|meta| PieceMetadata {
+                piece_key: c_str_to_rust_str(meta.piece_key).to_string(),
+                num_bytes: UnpaddedBytesAmount(meta.num_bytes),
+                comm_p: meta.comm_p,
+            })
+            .collect();
+
+        match (*ptr).import_sealed_sector(
+            SectorId::from(sector_id),
+            c_str_to_pbuf(sector_cache_dir_path),
+            c_str_to_pbuf(sealed_sector_path),
+            seal_ticket.into(),
+            seal_seed.into(),
+            *comm_r,
+            *comm_d,
+            PersistentAux {
+                comm_c: comm_c.unwrap(),
+                comm_r_last: comm_r_last.unwrap(),
+            },
+            pieces,
+            Vec::from_raw_parts(proof_ptr, proof_len, proof_len)
+                .iter()
+                .cloned()
+                .collect(),
+        ) {
+            Ok(_) => {
+                response.status_code = FCPResponseStatus::FCPNoError;
+            }
+            Err(err) => {
+                response.set_error(err_code_and_msg(&err));
+            }
+        }
+
+        info!("import_sealed_sector: {}", "finish");
+
+        raw_ptr(response)
+    })
+}
+
+/// Acquires a new sector id to be used when sealing out-of-band.
+///
+#[no_mangle]
+pub unsafe extern "C" fn sector_builder_ffi_acquire_sector_id(
+    ptr: *mut SectorBuilder,
+) -> *mut types::AcquireSectorIdResponse {
+    catch_panic_response(|| {
+        init_log();
+
+        info!("acquire_sector_id: {}", "start");
+
+        let mut response: types::AcquireSectorIdResponse = Default::default();
+
+        match (*ptr).acquire_sector_id() {
+            Ok(sector_id) => {
+                response.status_code = FCPResponseStatus::FCPNoError;
+                response.sector_id = sector_id.into();
+            }
+            Err(err) => {
+                response.set_error(err_code_and_msg(&err));
+            }
+        }
+
+        info!("acquire_sector_id: {}", "finish");
+
+        raw_ptr(response)
+    })
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // DESTRUCTORS
 //////////////
@@ -644,6 +762,24 @@ pub unsafe extern "C" fn sector_builder_ffi_destroy_seal_pre_commit_sector_respo
 #[no_mangle]
 pub unsafe extern "C" fn sector_builder_ffi_destroy_resume_seal_commit_sector_response(
     ptr: *mut types::ResumeSealCommitResponse,
+) {
+    let _ = Box::from_raw(ptr);
+}
+
+/// Destroys a ImportSealedSectorResponse.
+///
+#[no_mangle]
+pub unsafe extern "C" fn sector_builder_ffi_destroy_import_sealed_sector_response(
+    ptr: *mut types::ImportSealedSectorResponse,
+) {
+    let _ = Box::from_raw(ptr);
+}
+
+/// Destroys a AcquireSectorIdResponse.
+///
+#[no_mangle]
+pub unsafe extern "C" fn sector_builder_ffi_destroy_acquire_sector_id_response(
+    ptr: *mut types::AcquireSectorIdResponse,
 ) {
     let _ = Box::from_raw(ptr);
 }

--- a/sector-builder-ffi/src/types.rs
+++ b/sector-builder-ffi/src/types.rs
@@ -531,6 +531,44 @@ impl Default for GetStagedSectorsResponse {
 
 code_and_message_impl!(GetStagedSectorsResponse);
 
+#[repr(C)]
+#[derive(DropStructMacro)]
+pub struct ImportSealedSectorResponse {
+    pub status_code: FCPResponseStatus,
+    pub error_msg: *const libc::c_char,
+}
+
+impl Default for ImportSealedSectorResponse {
+    fn default() -> ImportSealedSectorResponse {
+        ImportSealedSectorResponse {
+            status_code: FCPResponseStatus::FCPNoError,
+            error_msg: ptr::null(),
+        }
+    }
+}
+
+code_and_message_impl!(ImportSealedSectorResponse);
+
+#[repr(C)]
+#[derive(DropStructMacro)]
+pub struct AcquireSectorIdResponse {
+    pub status_code: FCPResponseStatus,
+    pub error_msg: *const libc::c_char,
+    pub sector_id: u64,
+}
+
+impl Default for AcquireSectorIdResponse {
+    fn default() -> AcquireSectorIdResponse {
+        AcquireSectorIdResponse {
+            status_code: FCPResponseStatus::FCPNoError,
+            error_msg: ptr::null(),
+            sector_id: 0,
+        }
+    }
+}
+
+code_and_message_impl!(AcquireSectorIdResponse);
+
 pub type SectorBuilder = sector_builder::SectorBuilder<FileDescriptorRef>;
 
 /// Filedescriptor, that does not drop the file descriptor when dropped.

--- a/sector-builder/src/builder.rs
+++ b/sector-builder/src/builder.rs
@@ -200,11 +200,12 @@ impl<R: 'static + Send + std::io::Read> SectorBuilder<R> {
 
     // Increments the manager's nonce and returns a newly-provisioned sector id.
     pub fn acquire_sector_id(&self) -> Result<SectorId> {
-        log_unrecov(self.run_blocking(|tx| SchedulerTask::AcquireSectorId(tx)))
+        log_unrecov(self.run_blocking(SchedulerTask::AcquireSectorId))
     }
 
     // Imports a sector sealed elsewhere. This function uses the rename system
     // call to take ownership of the cache directory and sealed sector file.
+    #[allow(clippy::too_many_arguments)]
     pub fn import_sealed_sector(
         &self,
         sector_id: SectorId,

--- a/sector-builder/src/builder.rs
+++ b/sector-builder/src/builder.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{mpsc, Arc, Mutex};
 
 use filecoin_proofs::error::ExpectWithBacktrace;
@@ -17,6 +17,7 @@ use crate::metadata_manager::SectorMetadataManager;
 use crate::scheduler::{PerformHealthCheck, Scheduler, SchedulerTask};
 use crate::state::SectorBuilderState;
 use crate::worker::*;
+use filecoin_proofs::PersistentAux;
 use std::io::Read;
 
 const FATAL_NOLOAD: &str = "could not load snapshot";
@@ -194,6 +195,41 @@ impl<R: 'static + Send + std::io::Read> SectorBuilder<R> {
     ) -> Result<Vec<u8>> {
         log_unrecov(self.run_blocking(|tx| {
             SchedulerTask::GeneratePoSt(Vec::from(comm_rs), *challenge_seed, faults, tx)
+        }))
+    }
+
+    // Increments the manager's nonce and returns a newly-provisioned sector id.
+    pub fn acquire_sector_id(&self) -> Result<SectorId> {
+        log_unrecov(self.run_blocking(|tx| SchedulerTask::AcquireSectorId(tx)))
+    }
+
+    // Imports a sector sealed elsewhere. This function uses the rename system
+    // call to take ownership of the cache directory and sealed sector file.
+    pub fn import_sealed_sector(
+        &self,
+        sector_id: SectorId,
+        sector_cache_dir: PathBuf,
+        sealed_sector: PathBuf,
+        seal_ticket: SealTicket,
+        seal_seed: SealSeed,
+        comm_r: [u8; 32],
+        comm_d: [u8; 32],
+        p_aux: PersistentAux,
+        pieces: Vec<PieceMetadata>,
+        proof: Vec<u8>,
+    ) -> Result<()> {
+        log_unrecov(self.run_blocking(|tx| SchedulerTask::ImportSector {
+            sector_id,
+            sector_cache_dir,
+            sealed_sector,
+            seal_ticket,
+            seal_seed,
+            comm_r,
+            comm_d,
+            p_aux,
+            pieces,
+            proof,
+            done_tx: tx,
         }))
     }
 

--- a/sector-builder/src/helpers/add_piece.rs
+++ b/sector-builder/src/helpers/add_piece.rs
@@ -125,18 +125,20 @@ fn compute_destination_sector_id(
     }
 }
 
+pub fn acquire_new_sector_id(sector_builder_state: &mut SectorBuilderState) -> SectorId {
+    let n = SectorId::from(u64::from(sector_builder_state.sector_id_nonce) + 1);
+    sector_builder_state.sector_id_nonce = n;
+    n
+}
+
 // Provisions a new staged sector and returns its sector_id. Not a pure
 // function; creates a sector access (likely a file), increments the sector id
 // nonce, and mutates the StagedState.
 fn provision_new_staged_sector(
     sector_manager: &SectorManager,
-    sector_builder_state: &mut SectorBuilderState,
+    mut sector_builder_state: &mut SectorBuilderState,
 ) -> Result<SectorId> {
-    let sector_id = {
-        let n = SectorId::from(u64::from(sector_builder_state.last_committed_sector_id) + 1);
-        sector_builder_state.last_committed_sector_id = n;
-        n
-    };
+    let sector_id = acquire_new_sector_id(&mut sector_builder_state);
 
     let access = sector_manager.new_staging_sector_access(sector_id)?;
 

--- a/sector-builder/src/helpers/get_seal_status.rs
+++ b/sector-builder/src/helpers/get_seal_status.rs
@@ -65,7 +65,7 @@ mod tests {
         );
 
         SectorBuilderState {
-            last_committed_sector_id: 4.into(),
+            sector_id_nonce: 4.into(),
             staged: StagedState {
                 sectors: staged_sectors,
             },

--- a/sector-builder/src/helpers/snapshots.rs
+++ b/sector-builder/src/helpers/snapshots.rs
@@ -87,7 +87,7 @@ mod tests {
             let sealed_state = Default::default();
 
             SectorBuilderState {
-                last_committed_sector_id: 100.into(),
+                sector_id_nonce: 100.into(),
                 staged: staged_state,
                 sealed: sealed_state,
             }
@@ -104,7 +104,7 @@ mod tests {
             let sealed_state = Default::default();
 
             SectorBuilderState {
-                last_committed_sector_id: 102.into(),
+                sector_id_nonce: 102.into(),
                 staged: staged_state,
                 sealed: sealed_state,
             }

--- a/sector-builder/src/metadata_manager.rs
+++ b/sector-builder/src/metadata_manager.rs
@@ -6,8 +6,8 @@ use std::path::PathBuf;
 use filecoin_proofs::error::ExpectWithBacktrace;
 use filecoin_proofs::pieces::get_piece_start_byte;
 use filecoin_proofs::{
-    PaddedBytesAmount, PrivateReplicaInfo, SealCommitOutput, SealPreCommitOutput, TemporaryAux,
-    UnpaddedBytesAmount,
+    compute_comm_d, verify_seal, PaddedBytesAmount, PersistentAux, PieceInfo, PrivateReplicaInfo,
+    SealCommitOutput, SealPreCommitOutput, TemporaryAux, UnpaddedBytesAmount,
 };
 use serde::{Deserialize, Serialize};
 use storage_proofs::sector::SectorId;
@@ -15,6 +15,7 @@ use storage_proofs::sector::SectorId;
 use helpers::SnapshotKey;
 
 use crate::error::Result;
+use crate::helpers::acquire_new_sector_id;
 use crate::kv_store::KeyValueStore;
 use crate::scheduler::{SealCommitResult, SealPreCommitResult};
 use crate::state::SectorBuilderState;
@@ -24,8 +25,9 @@ use crate::worker::{
 };
 use crate::GetSealedSectorResult::WithHealth;
 use crate::{
-    err_piecenotfound, err_unrecov, GetSealedSectorResult, PersistablePreCommitOutput, SealSeed,
-    SealStatus, SealedSectorMetadata, SecondsSinceEpoch, SectorStore, StagedSectorMetadata,
+    err_piecenotfound, err_unrecov, GetSealedSectorResult, PersistablePreCommitOutput,
+    PieceMetadata, SealSeed, SealStatus, SealedSectorMetadata, SecondsSinceEpoch, SectorStore,
+    StagedSectorMetadata,
 };
 use crate::{helpers, SealTicket};
 
@@ -447,6 +449,175 @@ impl<T: KeyValueStore> SectorMetadataManager<T> {
 
             Ok(buffer)
         })
+    }
+
+    pub fn import_sector(
+        &mut self,
+        sector_id: SectorId,
+        sector_cache_dir: PathBuf,
+        sealed_sector: PathBuf,
+        seal_ticket: SealTicket,
+        seal_seed: SealSeed,
+        comm_r: [u8; 32],
+        comm_d: [u8; 32],
+        p_aux: PersistentAux,
+        pieces: Vec<PieceMetadata>,
+        proof: Vec<u8>,
+    ) -> Result<()> {
+        let stor = &self.sector_store;
+        let mngr = stor.manager();
+        let pcfg = stor.proofs_config().porep_config;
+        let scfg = stor.sector_config();
+
+        if sector_id > self.state.sector_id_nonce {
+            return Err(format_err!(
+                "sector import was provided an id {:?} that it did not acquire from the builder (sector_id_none = {:?})",
+                sector_id,
+                self.state.sector_id_nonce,
+            ));
+        }
+
+        if self.state.staged.sectors.contains_key(&sector_id) {
+            return Err(format_err!(
+                "sector import was provided an id {:?} that is already taken by a staged sector",
+                sector_id,
+            ));
+        }
+
+        if self.state.sealed.sectors.contains_key(&sector_id) {
+            return Err(format_err!(
+                "sector import was provided an id {:?} that is already taken by a sealed sector",
+                sector_id,
+            ));
+        }
+
+        // verify the provided proof
+        match verify_seal(
+            pcfg,
+            comm_r,
+            comm_d,
+            self.prover_id,
+            sector_id,
+            seal_ticket.ticket_bytes,
+            seal_seed.ticket_bytes,
+            &proof,
+        ) {
+            Err(err) => {
+                return Err(format_err!(
+                    "sector import (id = {:?}) saw error verifying seal proof: {:?}",
+                    sector_id,
+                    err
+                ));
+            }
+            Ok(false) => {
+                return Err(format_err!(
+                    "proof provided to sector import (id = {:?}) was invalid",
+                    sector_id
+                ));
+            }
+            Ok(_) => {} // noop
+        };
+
+        // compute a comm_d
+        let computed_comm_d = compute_comm_d(
+            pcfg,
+            &pieces
+                .iter()
+                .cloned()
+                .map(Into::into)
+                .collect::<Vec<PieceInfo>>(),
+        )
+        .map_err(|err| format_err!("sector import failed to compute comm_d: {:?}", err))?;
+
+        // verify that the computed comm_d matches what we were provided
+        if comm_d != computed_comm_d {
+            return Err(format_err!(
+                "comm_d provided to sector import (id = {:?}) did not match comm_d computed from pieces",
+                sector_id
+            ));
+        }
+
+        // ensure that the file has the appropriate quantity of bytes
+        let len = std::fs::metadata(&sealed_sector)?.len();
+        let max = scfg.sector_bytes;
+
+        if len != u64::from(max) {
+            return Err(format_err!(
+                "import file (id = {:?}) contains {:?} bytes but must contain {:?}",
+                sector_id,
+                len,
+                max
+            ));
+        }
+
+        // generate checksum
+        let blake2b_checksum = helpers::calculate_checksum(&sealed_sector)?
+            .as_ref()
+            .to_vec();
+
+        let access = mngr
+            .convert_sector_id_to_access_name(sector_id)
+            .map_err(|err| {
+                format_err!(
+                    "sector id {:?} could not be xformed to access: {:?}",
+                    sector_id,
+                    err
+                )
+            })?;
+
+        let new_sector_path = mngr.sealed_sector_path(&access);
+        let new_cache_path = mngr.cache_path(&access);
+
+        let _ = std::fs::copy(&sealed_sector, &new_sector_path).map_err(|err| {
+            format_err!(
+                "import failed to copy sector (id = {:?}) from {:?} to {:?} (err = {:?})",
+                sector_id,
+                sealed_sector,
+                new_sector_path,
+                err
+            )
+        })?;
+
+        let _ = std::fs::rename(&sector_cache_dir, &new_cache_path).map_err(|err| {
+            format_err!(
+                "import failed to move sector cache path (id = {:?}) from {:?} to {:?} (err = {:?})",
+                sector_id,
+                sector_cache_dir,
+                new_cache_path,
+                err
+            )
+        })?;
+
+        // safe to delete old sector file now
+        if let Err(err) = std::fs::remove_file(&sealed_sector) {
+            warn!(
+                "sector import failed to remove imported sector (id = {:?}) at path {:?} (err = {:?})",
+                sector_id, sealed_sector, err
+            );
+        }
+
+        let meta = SealedSectorMetadata {
+            sector_id,
+            sector_access: access,
+            pieces,
+            comm_r,
+            comm_d,
+            proof,
+            blake2b_checksum,
+            len,
+            p_aux,
+            ticket: seal_ticket,
+            seed: seal_seed,
+        };
+
+        let _ = self.state.sealed.sectors.insert(sector_id, meta);
+
+        Ok(())
+    }
+
+    // Increments the nonce and returns the new value.
+    pub fn acquire_sector_id(&mut self) -> SectorId {
+        acquire_new_sector_id(&mut self.state)
     }
 
     // Update metadata to reflect the seal pre-commit result. Propagates the

--- a/sector-builder/src/metadata_manager.rs
+++ b/sector-builder/src/metadata_manager.rs
@@ -451,6 +451,7 @@ impl<T: KeyValueStore> SectorMetadataManager<T> {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn import_sector(
         &mut self,
         sector_id: SectorId,
@@ -578,7 +579,7 @@ impl<T: KeyValueStore> SectorMetadataManager<T> {
             )
         })?;
 
-        let _ = std::fs::rename(&sector_cache_dir, &new_cache_path).map_err(|err| {
+        std::fs::rename(&sector_cache_dir, &new_cache_path).map_err(|err| {
             format_err!(
                 "import failed to move sector cache path (id = {:?}) from {:?} to {:?} (err = {:?})",
                 sector_id,

--- a/sector-builder/src/state.rs
+++ b/sector-builder/src/state.rs
@@ -17,15 +17,15 @@ pub struct SealedState {
 
 #[derive(Default, Serialize, Deserialize, Debug, PartialEq)]
 pub struct SectorBuilderState {
-    pub last_committed_sector_id: SectorId,
+    pub sector_id_nonce: SectorId,
     pub staged: StagedState,
     pub sealed: SealedState,
 }
 
 impl SectorBuilderState {
-    pub fn new(last_committed_sector_id: SectorId) -> SectorBuilderState {
+    pub fn new(initial_sector_id: SectorId) -> SectorBuilderState {
         SectorBuilderState {
-            last_committed_sector_id,
+            sector_id_nonce: initial_sector_id,
             staged: StagedState {
                 sectors: Default::default(),
             },


### PR DESCRIPTION
## Why does this PR exist?

This PR adds support for importing a sector sealed elsewhere. It blocks the merge of [this downstream PR](https://github.com/filecoin-project/go-sectorbuilder/pull/46).