### PR TITLE
feat(params): v15 to v17 parameter upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,7 +341,7 @@ commands:
   restore_parameter_cache:
     steps:
       - restore_cache:
-          key: v15b-proof-params-{{ arch }}
+          key: v17-proof-params-{{ arch }}
           paths:
             - /tmp/filecoin-parameter-cache
   restore_rust_cache:
@@ -351,7 +351,7 @@ commands:
   save_parameter_cache:
     steps:
       - save_cache:
-          key: v15b-proof-params-{{ arch }}
+          key: v17-proof-params-{{ arch }}
           paths:
             - /tmp/filecoin-parameter-cache
   save_rust_cache:


### PR DESCRIPTION
We've upgraded to v17 Groth parameters, but our cache keys (CircleCI) need updating to reflect this.