### PR TITLE
[WIP] fix(paramcache): respect lockfile when installing paramcache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
       - run:
           name: Generate Groth parameters and verifying keys
           command: paramcache
+          no_output_timeout: 30m
       - save_parameter_cache
 
   cargo_fetch:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - run:
           name: Install paramcache from head of rust-fil-proofs master branch
           command: |
-            cargo install filecoin-proofs --bin=paramcache --force --git=https://github.com/filecoin-project/rust-fil-proofs.git --branch=master
+            cargo install filecoin-proofs --bin=paramcache --locked --force
             which paramcache || { printf '%s\n' "missing paramcache binary" >&2; exit 1; }
       - restore_parameter_cache
       - run:


### PR DESCRIPTION
## What's in this PR?

- Install `paramcache` while respecting the Cargo.lock file (instead of always installing from the head of master)
- Bump CircleCI no-output timeout to 30m to prevent, well, timeouts