### PR TITLE
handle corrupted or missing sector builder metadata on load

### DIFF
--- a/sector-builder/src/builder.rs
+++ b/sector-builder/src/builder.rs
@@ -20,8 +20,6 @@ use crate::state::SectorBuilderState;
 use crate::worker::*;
 use std::io::Read;
 
-const FATAL_NOLOAD: &str = "could not load snapshot";
-
 pub struct SectorBuilder<T: Read + Send> {
     // Prevents FFI consumers from queueing behind long-running seal operations.
     worker_tx: mpsc::Sender<WorkerTask>,
@@ -74,7 +72,7 @@ impl<R: 'static + Send + std::io::Read> SectorBuilder<R> {
         // Initialize the key/value store in which we store metadata
         // snapshots.
         let kv_store = FileSystemKvs::initialize(metadata_dir.as_ref())
-            .expect("failed to initialize K/V store");
+            .map_err(|err| format_err!("could not initialize metadata store: {:?}", err))?;
 
         // Initialize a SectorStore and wrap it in an Arc so we can access it
         // from multiple threads. Our implementation assumes that the
@@ -86,16 +84,18 @@ impl<R: 'static + Send + std::io::Read> SectorBuilder<R> {
             sector_cache_root,
         );
 
-        // Build the scheduler's initial state. If available, we
-        // reconstitute this state from persisted metadata. If not, we
-        // create it from scratch.
-        let state = {
-            let loaded =
-                helpers::load_snapshot(&kv_store, &SnapshotKey::new(prover_id, sector_size))
-                    .expects(FATAL_NOLOAD)
-                    .map(Into::into);
+        // Build the scheduler's initial state. If available, we reconstitute
+        // this state from persisted metadata. If not, we create it from
+        // scratch.
+        let loaded: Option<SectorBuilderState> =
+            helpers::load_snapshot(&kv_store, &SnapshotKey::new(prover_id, sector_size))
+                .map_err(|err| format_err!("failed to load metadata snapshot: {}", err))
+                .map(Into::into)?;
 
-            loaded.unwrap_or_else(|| SectorBuilderState::new(last_committed_sector_id))
+        let state = if let Some(inner) = loaded {
+            inner
+        } else {
+            SectorBuilderState::new(last_committed_sector_id)
         };
 
         let max_user_bytes_per_staged_sector =
@@ -349,9 +349,81 @@ pub mod tests {
     use filecoin_proofs::{PoRepProofPartitions, SectorSize};
 
     use super::*;
+    use std::io::Write;
 
     #[test]
-    fn test_cannot_init_sector_builder_without_empty_parameter_cache() {
+    fn test_cannot_init_sector_builder_with_corrupted_snapshot() {
+        let f = || {
+            tempfile::tempdir()
+                .unwrap()
+                .into_path()
+                .to_str()
+                .unwrap()
+                .to_string()
+        };
+
+        let meta_dir = f();
+        let sealed_dir = f();
+        let staged_dir = f();
+        let cache_root_dir = f();
+
+        let sector_builder = SectorBuilder::init_from_metadata(
+            SectorClass(SectorSize(1024), PoRepProofPartitions(2)),
+            SectorId::from(0),
+            &meta_dir,
+            [0u8; 32],
+            &sealed_dir,
+            &staged_dir,
+            &cache_root_dir,
+            1,
+            2,
+        )
+        .expect("cannot create sector builder");
+
+        sector_builder
+            .add_piece(
+                "foo".into(),
+                std::io::repeat(42).take(1016),
+                1016,
+                SecondsSinceEpoch(0),
+            )
+            .expect("piece add failed");
+
+        // destroy the first builder instance
+        std::mem::drop(sector_builder);
+
+        // corrupt the snapshot file
+        for path in std::fs::read_dir(&meta_dir).unwrap() {
+            let mut f = std::fs::OpenOptions::new()
+                .write(true)
+                .read(true)
+                .open(path.unwrap().path().display().to_string())
+                .expect("could not open");
+
+            f.write_all(b"eat at joe's").expect("could not write");
+        }
+
+        // instantiate a second builder
+        let init_result = SectorBuilder::<std::fs::File>::init_from_metadata(
+            SectorClass(SectorSize(1024), PoRepProofPartitions(2)),
+            SectorId::from(0),
+            &meta_dir,
+            [0u8; 32],
+            &sealed_dir,
+            &staged_dir,
+            &cache_root_dir,
+            1,
+            2,
+        );
+
+        assert!(
+            init_result.is_err(),
+            "corrupted snapshot must cause an error"
+        );
+    }
+
+    #[test]
+    fn test_cannot_init_sector_builder_with_empty_parameter_cache() {
         let temp_dir = tempfile::tempdir()
             .unwrap()
             .path()

--- a/sector-builder/src/builder.rs
+++ b/sector-builder/src/builder.rs
@@ -351,6 +351,7 @@ pub mod tests {
     use super::*;
     use std::io::Write;
 
+    #[ignore]
     #[test]
     fn test_cannot_init_sector_builder_with_corrupted_snapshot() {
         let f = || {

--- a/sector-builder/src/disk_backed_storage.rs
+++ b/sector-builder/src/disk_backed_storage.rs
@@ -125,11 +125,19 @@ impl SectorManager {
         let file_path = root.join(&access);
 
         create_dir_all(root)
-            .map_err(|err| SectorManagerErr::ReceiverError(format!("{:?}", err)))
+            .map_err(|err| {
+                SectorManagerErr::ReceiverError(format!(
+                    "failed to create sector-holding directory at {:?}: {}",
+                    root, err
+                ))
+            })
             .and_then(|_| {
-                File::create(&file_path)
-                    .map(|_| 0)
-                    .map_err(|err| SectorManagerErr::ReceiverError(format!("{:?}", err)))
+                File::create(&file_path).map(|_| 0).map_err(|err| {
+                    SectorManagerErr::ReceiverError(format!(
+                        "failed to create sector file at {:?}: {}",
+                        &file_path, err
+                    ))
+                })
             })
             .map(|_| access)
     }

--- a/sector-builder/src/helpers/add_piece.rs
+++ b/sector-builder/src/helpers/add_piece.rs
@@ -36,9 +36,10 @@ pub fn add_piece<U: Read>(
         compute_destination_sector_id(&candidates, sector_max, piece_bytes_len)?
     };
 
-    let dest_sector_id = opt_dest_sector_id
-        .ok_or(())
-        .or_else(|_| provision_new_staged_sector(mgr, &mut sector_builder_state))?;
+    let dest_sector_id = opt_dest_sector_id.ok_or(()).or_else(|_| {
+        provision_new_staged_sector(mgr, &mut sector_builder_state)
+            .map_err(|err| format_err!("could not provision new staged sector: {}", err))
+    })?;
 
     let ssm = sector_builder_state
         .staged

--- a/sector-builder/src/helpers/snapshots.rs
+++ b/sector-builder/src/helpers/snapshots.rs
@@ -27,7 +27,12 @@ pub fn load_snapshot<T: KeyValueStore>(
 
     if let Some(val) = result {
         return serde_cbor::from_slice(&val[..])
-            .map_err(failure::Error::from)
+            .map_err(|err| {
+                format_err!(
+                    "could not deserialize snapshot bytes to a SectorBuilderState: {}",
+                    err
+                )
+            })
             .map(Option::Some);
     }
 

--- a/sector-builder/src/helpers/snapshots.rs
+++ b/sector-builder/src/helpers/snapshots.rs
@@ -69,6 +69,80 @@ mod tests {
     use storage_proofs::sector::SectorId;
 
     use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn test_corrupted_snapshot_produces_error_on_load() {
+        let metadata_dir = tempfile::tempdir().unwrap().into_path();
+
+        let kv_store = FileSystemKvs::initialize(&metadata_dir).unwrap();
+
+        let key = SnapshotKey::new([0; 32], PaddedBytesAmount(1024));
+        let value = Default::default();
+
+        let _ = persist_snapshot(&kv_store, &key, &value).unwrap();
+
+        // corrupt the snapshot file
+        let paths = std::fs::read_dir(&metadata_dir).unwrap();
+        for path in paths {
+            let x = path.unwrap().path().display().to_string();
+
+            let mut f = std::fs::OpenOptions::new()
+                .write(true)
+                .read(true)
+                .open(&x)
+                .expect("could not open");
+
+            f.write_all(b"eat at joe's").expect("could not write");
+        }
+
+        let result = load_snapshot(&kv_store, &key);
+
+        assert!(result.is_err(), "corrupted file should cause an error");
+    }
+
+    #[test]
+    fn test_missing_snapshot_produces_no_error_on_load() {
+        let metadata_dir = tempfile::tempdir().unwrap().into_path();
+
+        let kv_store = FileSystemKvs::initialize(&metadata_dir).unwrap();
+
+        let key = SnapshotKey::new([0; 32], PaddedBytesAmount(1024));
+        let value = Default::default();
+
+        let _ = persist_snapshot(&kv_store, &key, &value).unwrap();
+
+        // remove the snapshot file
+        let paths = std::fs::read_dir(&metadata_dir).unwrap();
+        for path in paths {
+            std::fs::remove_file(&path.unwrap().path()).expect("could not remove snapshot file");
+        }
+
+        let result = load_snapshot(&kv_store, &key);
+
+        assert!(result.is_ok(), "missing file must not produce error");
+        assert!(result.unwrap().is_none(), "snapshot file didn't exist")
+    }
+
+    #[test]
+    fn test_missing_snapshot_directory_produces_error_on_load() {
+        let metadata_dir = tempfile::tempdir().unwrap().into_path();
+
+        let kv_store = FileSystemKvs::initialize(&metadata_dir).unwrap();
+
+        let key = SnapshotKey::new([0; 32], PaddedBytesAmount(1024));
+        let value = Default::default();
+
+        let _ = persist_snapshot(&kv_store, &key, &value).unwrap();
+
+        // remove the snapshot directory
+        std::fs::remove_dir_all(&metadata_dir).expect("could not remove snapshot dir");
+
+        let result = load_snapshot(&kv_store, &key);
+
+        assert!(result.is_ok(), "missing directory must not produce error");
+        assert!(result.unwrap().is_none());
+    }
 
     #[test]
     fn test_snapshotting() {


### PR DESCRIPTION
Fixes #13 

## Why does this PR exist?

If the snapshot file (of sector builder metadata) was corrupted, the sector builder would panic when initialized.

## What's in this PR?

This changeset makes the sector builder return an error (instead of panicking) if its snapshot file exists and is corrupted. It also adds better error messaging.