### PR TITLE
deprecate project in favor of filecoin-ffi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-# Filecoin Sector Builder
+# DEPRECATED
 
+This repo is no longer supported. Please consider using
+[filecoin-ffi](https://github.com/filecoin-project/filecoin-ffi) instead.
 
 ## Contributing
 

--- a/sector-builder-ffi/Cargo.toml
+++ b/sector-builder-ffi/Cargo.toml
@@ -9,6 +9,9 @@ readme = "README.md"
 edition = "2018"
 publish = false
 
+[badges]
+maintenance = { status = "deprecated" }
+
 [lib]
 # cdylib is required by the FFI example/test
 crate-type = ["rlib", "cdylib", "staticlib"]

--- a/sector-builder/Cargo.toml
+++ b/sector-builder/Cargo.toml
@@ -9,6 +9,9 @@ repository = "https://github.com/filecoin-project/rust-fil-proofs"
 readme = "README.md"
 publish = false
 
+[badges]
+maintenance = { status = "deprecated" }
+
 [dependencies]
 bitvec = "0.11"
 failure = "0.1.5"


### PR DESCRIPTION
## Why does this PR exist?

We've combined proofs and bls FFI code (both CGO and C-like Rusty bindings) into a [new repo](https://github.com/filecoin-project/filecoin-ffi), which means that we can stop depending on this repo.